### PR TITLE
Creazione ordine da preventivo + fix minori

### DIFF
--- a/modules/preventivi/buttons.php
+++ b/modules/preventivi/buttons.php
@@ -1,0 +1,26 @@
+<?php
+
+include_once __DIR__.'/../../core.php';
+
+if (!in_array($records[0]['stato'], ['Bozza','Rifiutato','In attesa di conferma'])) {
+
+echo '
+	<div class="dropdown">
+	<button class="btn btn-info dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+		<i class="fa fa-magic"></i>&nbsp;'.tr('Crea').'...
+		<span class="caret"></span>
+	</button>
+	<ul class="dropdown-menu">
+			
+			<li>
+				<a data-href="'.$rootdir.'/modules/ordini/crea_documento.php?id_module='.$id_module.'&id_record='.$id_record.'&documento=ordine" data-toggle="modal" data-title="'.tr('Crea ordine').'" data-target="#bs-popup"><i class="fa fa-file-o"></i>&nbsp;'.tr('Ordine').'
+				</a>
+			</li>
+
+			
+
+		</ul>
+	</div>';
+
+	
+}

--- a/modules/preventivi/edit.php
+++ b/modules/preventivi/edit.php
@@ -134,11 +134,11 @@ $_SESSION['superselect']['idanagrafica'] = $records[0]['idanagrafica'];
         <?php if ($records[0]['stato'] != 'Pagato') {
                         ?>
 
-        <a class="btn btn-primary" data-href="<?php echo $rootdir; ?>/modules/contratti/row-add.php?id_module=<?php echo $id_module; ?>&id_record=<?php echo $id_record; ?>&is_articolo" data-toggle="modal" data-title="Aggiungi articolo" data-target="#bs-popup"><i class="fa fa-plus"></i> <?php echo tr('Articolo'); ?></a>
+        <a class="btn btn-primary" data-href="<?php echo $rootdir; ?>/modules/preventivi/row-add.php?id_module=<?php echo $id_module; ?>&id_record=<?php echo $id_record; ?>&is_articolo" data-toggle="modal" data-title="Aggiungi articolo" data-target="#bs-popup"><i class="fa fa-plus"></i> <?php echo tr('Articolo'); ?></a>
 
-        <a class="btn btn-primary" data-href="<?php echo $rootdir; ?>/modules/contratti/row-add.php?id_module=<?php echo $id_module; ?>&id_record=<?php echo $id_record; ?>&is_riga" data-toggle="modal" data-title="Aggiungi riga" data-target="#bs-popup"><i class="fa fa-plus"></i> <?php echo tr('Riga'); ?></a>
+        <a class="btn btn-primary" data-href="<?php echo $rootdir; ?>/modules/preventivi/row-add.php?id_module=<?php echo $id_module; ?>&id_record=<?php echo $id_record; ?>&is_riga" data-toggle="modal" data-title="Aggiungi riga" data-target="#bs-popup"><i class="fa fa-plus"></i> <?php echo tr('Riga'); ?></a>
 
-        <a class="btn btn-primary" data-href="<?php echo $rootdir; ?>/modules/contratti/row-add.php?id_module=<?php echo $id_module; ?>&id_record=<?php echo $id_record; ?>&is_descrizione" data-toggle="modal" data-title="Aggiungi descrizione" data-target="#bs-popup"><i class="fa fa-plus"></i> <?php echo tr('Descrizione'); ?></a>
+        <a class="btn btn-primary" data-href="<?php echo $rootdir; ?>/modules/preventivi/row-add.php?id_module=<?php echo $id_module; ?>&id_record=<?php echo $id_record; ?>&is_descrizione" data-toggle="modal" data-title="Aggiungi descrizione" data-target="#bs-popup"><i class="fa fa-plus"></i> <?php echo tr('Descrizione'); ?></a>
 
         <?php
                     } ?>


### PR DESCRIPTION
## Descrizione

Mi scuso innanzitutto per la pull request "mista".

1) Dal modulo preventivi i pulsanti "Riga", "Articolo", "Descrizione" puntavano ai file della cartella "contratti" e non a "preventivi".

2) Nella procedura di creazione automatica delle fatture a partire dagli ordini o dai ddt, non veniva mantenuto l'ordine delle righe del documento.

3) Ho implementato la funzionalità di creazione di un ordine cliente a partire da un preventivo. Ho testato gli articoli, le righe, le descrizioni, gli sconti unitari e percentuali.

## Tipologia

- [ ] Bug fix
- [ ] Nuova funzionalità

# Checklist

- [ ] Il codice segue le linee guida del progetto
- [ ] Ho commentato il codice, in particolare nelle parti più complesse
- [ ] Il codice non genera warnings