### PR TITLE
Prezzo di acquisto e guadagno - Fatture di vendita e preventivi

### DIFF
--- a/include/common/riga.php
+++ b/include/common/riga.php
@@ -26,19 +26,65 @@ echo '
         </div>
     </div>';
 
-// Costo unitario
+// Prezzo di acquisto unitario
 echo '
     <div class="row">
-        <div class="col-md-6">
-            {[ "type": "number", "label": "'.tr('Costo unitario').'", "name": "prezzo", "value": "'.$result['prezzo'].'", "required": 1, "icon-after": "&euro;" ]}
+        <div class="col-md-3">
+            {[ "type": "number", "label": "'.tr('Prezzo di acquisto unitario').'", "name": "prezzo_acquisto", "value": "'.$result['prezzo_unitario_acquisto'].'", "required": 0, "icon-after": "&euro;", "onkeyup": "aggiorna_guadagno()" ]}
+        </div>';
+
+// Prezzo di vendita unitario
+echo '
+        <div class="col-md-3">
+            {[ "type": "number", "label": "'.tr('Prezzo di vendita unitario').'", "name": "prezzo", "value": "'.$result['prezzo'].'", "required": 1, "icon-after": "&euro;", "onkeyup": "aggiorna_guadagno()" ]}
         </div>';
 
 // Sconto unitario
 echo '
-        <div class="col-md-6">
-            {[ "type": "number", "label": "'.tr('Sconto unitario').'", "name": "sconto", "value": "'.$result['sconto_unitario'].'", "icon-after": "choice|untprc|'.$result['tipo_sconto'].'" ]}
+        <div class="col-md-3">
+            {[ "type": "number", "label": "'.tr('Sconto unitario').'", "name": "sconto", "value": "'.$result['sconto_unitario'].'", "icon-after": "choice|untprc|'.$result['tipo_sconto'].'", "onkeyup": "aggiorna_guadagno()"]}
+        </div>';
+
+// Guadagno
+echo '
+        <div class="col-md-3">
+            {[ "type": "number", "label": "'.tr('Guadagno').'", "name": "guadagno", "value": "'.$result['sconto_unitario'].'", "icon-after": "&euro;", "disabled": 1 ]}
         </div>
     </div>';
+
+// Funzione per l'aggiornamento in tempo reale del guadagno
+
+echo '
+<script>
+function aggiorna_guadagno() {
+    var prezzo_acquisto = parseFloat($("#prezzo_acquisto").val().replace(/\./g, ""));
+    var prezzo = parseFloat($("#prezzo").val().replace(/\./g, ""));
+    var sconto = parseFloat($("#sconto").val().replace(/\./g, ""));
+    if ($("#tipo_sconto").val() === "PRC") {
+        sconto = sconto / 100 * prezzo
+    }
+    var guadagno = $("#guadagno");
+    var parentdiv = guadagno.parent();
+    var errorsdiv = parentdiv.parent().find("div[id*=\'errors\']");
+    guadagno.val(prezzo - sconto - prezzo_acquisto);
+    if (parseFloat(guadagno.val().replace(/\./g, "")) < 0) {
+        guadagno.css("color", "red");
+        parentdiv.addClass("has-error");
+        errorsdiv.addClass("has-error");
+        if (errorsdiv.find(".help-block").length === 0) {
+            errorsdiv.append("<span class=\'help-block\'>Il guadagno è negativo!</span>");
+        }
+    } else {
+        guadagno.css("color", "black");
+        parentdiv.removeClass("has-error");
+        errorsdiv.removeClass("has-error");
+        errorsdiv.find(".help-block").remove()
+    }
+}
+aggiorna_guadagno();
+$("#tipo_sconto").change(aggiorna_guadagno)
+</script>
+';
 
 if ($module['name'] == 'Fatture di vendita') {
     $collapsed = empty($result['data_inizio_periodo']) && empty($result['data_fine_periodo']) && empty($result['riferimento_amministrazione']);

--- a/modules/fatture/actions.php
+++ b/modules/fatture/actions.php
@@ -621,6 +621,7 @@ switch (post('op')) {
             $riga->id_rivalsa_inps = post('id_rivalsa_inps');
         }
 
+        $riga->prezzo_unitario_acquisto = post("prezzo_acquisto");
         $riga->prezzo_unitario_vendita = post('prezzo');
         $riga->qta = $qta;
         $riga->sconto_unitario = post('sconto');

--- a/modules/fatture/row-list.php
+++ b/modules/fatture/row-list.php
@@ -16,8 +16,10 @@ echo '
             <th>'.tr('Descrizione').'</th>
             <th width="120">'.tr('Q.tà').'</th>
             <th width="80">'.tr('U.m.').'</th>
-            <th width="120">'.tr('Prezzo unitario').'</th>
+            <th width="150">'.tr('Prezzo acq. unitario').'</th>
+            <th width="160">'.tr('Prezzo vend. unitario').'</th>
             <th width="120">'.tr('Iva').'</th>
+            <th width="150">'.tr('Guadagno unitario').'</th>
             <th width="120">'.tr('Importo').'</th>
             <th width="60"></th>
         </tr>
@@ -28,6 +30,7 @@ if (!empty($rs)) {
     foreach ($rs as $r) {
         // Valori assoluti
         $r['qta'] = abs($r['qta']);
+        $r['prezzo_unitario_acquisto'] = abs($r['prezzo_unitario_acquisto']);
         $r['subtotale'] = abs($r['subtotale']);
         $r['sconto_unitario'] = abs($r['sconto_unitario']);
         $r['sconto'] = abs($r['sconto']);
@@ -143,7 +146,16 @@ if (!empty($rs)) {
         echo '
         </td>';
 
-        // Prezzo unitario
+        // Prezzo di acquisto unitario
+        echo '
+        <td class="text-right">';
+
+        if (empty($r['is_descrizione'])) {
+            echo '
+            '.Translator::numberToLocale($r['prezzo_unitario_acquisto']).' &euro;';
+        }
+
+        // Prezzo di vendita unitario
         echo '
         <td class="text-right">';
 
@@ -173,6 +185,22 @@ if (!empty($rs)) {
             <br><small class="help-block">'.$r['desc_iva'].'</small>';
         }
 
+        echo '
+        </td>';
+
+        // Guadagno
+        $guadagno = $r['subtotale'] - (($r['prezzo_unitario_acquisto'] - $r["sconto_unitario"]) * $r["qta"]);
+        if ($guadagno < 0) {
+            $guadagno_style = "background-color: #FFC6C6; border: 3px solid red";
+        } else {
+            $guadagno_style = "";
+        }
+        echo '
+        <td class="text-right" style="' . $guadagno_style . '">';
+        if (empty($r['is_descrizione'])) {
+            echo '
+            '.Translator::numberToLocale($guadagno).' &euro;';
+        }
         echo '
         </td>';
 
@@ -236,6 +264,10 @@ echo '
     </tbody>';
 
 // Calcoli
+$totale_acquisto = 0;
+foreach ($rs as $r) {
+    $totale_acquisto += ($r["prezzo_unitario_acquisto"] * $r["qta"]);
+}
 $imponibile = sum(array_column($rs, 'subtotale'));
 $sconto = sum(array_column($rs, 'sconto'));
 $iva = sum(array_column($rs, 'iva'));
@@ -264,10 +296,15 @@ $totale_iva = abs($totale_iva);
 $totale = abs($totale);
 $netto_a_pagare = abs($netto_a_pagare);
 
+$totale_guadagno = sum([
+    $imponibile_scontato
+    -$totale_acquisto
+]);
+
 // IMPONIBILE
 echo '
     <tr>
-        <td colspan="5" class="text-right">
+        <td colspan="7" class="text-right">
             <b>'.tr('Imponibile', [], ['upper' => true]).':</b>
         </td>
         <td align="right">
@@ -280,7 +317,7 @@ echo '
 if (abs($sconto) > 0) {
     echo '
     <tr>
-        <td colspan="5" class="text-right">
+        <td colspan="7" class="text-right">
             <b>'.tr('Sconto', [], ['upper' => true]).':</b>
         </td>
         <td align="right">
@@ -292,7 +329,7 @@ if (abs($sconto) > 0) {
     // IMPONIBILE SCONTATO
     echo '
     <tr>
-        <td colspan="5" class="text-right">
+        <td colspan="7" class="text-right">
             <b>'.tr('Imponibile scontato', [], ['upper' => true]).':</b>
         </td>
         <td align="right">
@@ -306,7 +343,7 @@ if (abs($sconto) > 0) {
 if (abs($record['rivalsainps']) > 0) {
     echo '
     <tr>
-        <td colspan="5" class="text-right">
+        <td colspan="7" class="text-right">
             <b>'.tr('Rivalsa INPS', [], ['upper' => true]).':</b>
         </td>
         <td align="right">
@@ -320,7 +357,7 @@ if (abs($record['rivalsainps']) > 0) {
 if (abs($totale_iva) > 0) {
     echo '
     <tr>
-        <td colspan="5" class="text-right">
+        <td colspan="7" class="text-right">
             <b>'.tr('Iva', [], ['upper' => true]).':</b>
         </td>
         <td align="right">
@@ -333,7 +370,7 @@ if (abs($totale_iva) > 0) {
 // TOTALE
 echo '
     <tr>
-        <td colspan="5" class="text-right">
+        <td colspan="7" class="text-right">
             <b>'.tr('Totale', [], ['upper' => true]).':</b>
         </td>
         <td align="right">
@@ -346,7 +383,7 @@ echo '
 if (abs($record['bollo']) > 0) {
     echo '
     <tr>
-        <td colspan="5" class="text-right">
+        <td colspan="7" class="text-right">
             <b>'.tr('Marca da bollo', [], ['upper' => true]).':</b>
         </td>
         <td align="right">
@@ -360,7 +397,7 @@ if (abs($record['bollo']) > 0) {
 if (abs($record['ritenutaacconto']) > 0) {
     echo '
     <tr>
-        <td colspan="5" class="text-right">
+        <td colspan="7" class="text-right">
             <b>'.tr("Ritenuta d'acconto", [], ['upper' => true]).':</b>
         </td>
         <td align="right">
@@ -376,7 +413,7 @@ if (abs($record['ritenutaacconto']) > 0) {
 if ($totale != $netto_a_pagare) {
     echo '
     <tr>
-        <td colspan="5" class="text-right">
+        <td colspan="7" class="text-right">
             <b>'.tr('Netto a pagare', [], ['upper' => true]).':</b>
         </td>
         <td align="right">
@@ -385,6 +422,23 @@ if ($totale != $netto_a_pagare) {
         <td></td>
     </tr>';
 }
+
+// GUADAGNO TOTALE
+if ($totale_guadagno < 0) {
+    $guadagno_style = "background-color: #FFC6C6; border: 3px solid red";
+} else {
+    $guadagno_style = "";
+}
+echo '
+    <tr>
+        <td colspan="7" class="text-right">
+            <b>'.tr('Guadagno totale', [], ['upper' => true]).':</b>
+        </td>
+        <td align="right" style="' . $guadagno_style . '">
+            '.Translator::numberToLocale($totale_guadagno).' &euro;
+        </td>
+        <td></td>
+    </tr>';
 
 echo '
 </table>';

--- a/update/2_4_4.sql
+++ b/update/2_4_4.sql
@@ -22,3 +22,7 @@ UPDATE `zz_views` SET `query` = '(SELECT `descrizione` FROM `fe_stati_documento`
 
 INSERT INTO `zz_settings` (`id`, `nome`, `valore`, `tipo`, `editable`, `sezione`, `order`) VALUES
 (NULL, 'OSMCloud Services API Token', '', 'string', 1, 'Fatturazione Elettronica', 11);
+
+-- Prezzo di acquisto
+
+ALTER TABLE `co_righe_documenti` ADD `prezzo_unitario_acquisto` DECIMAL(12,4) NOT NULL AFTER `descrizione`;


### PR DESCRIPTION
## Descrizione

### Aggiunto
Nuovi campi quando si aggiunge una riga in una fattura e/o un preventivo:
- Prezzo di acquisto (prezzo del prodotto quando acquistato dal fornitore)
- Guadagno (la differenza tra il prezzo di vendita e il prezzo di acquisto)

> Questi campi non vengono visualizzati nelle stampe in PDF ed invio via email. Vengono visualizzati solo nella tabella di riepilogo
- Bordo rosso e sfondo rosso chiaro nelle celle della tabella con guadagno negativo:
![immagine](https://user-images.githubusercontent.com/9463142/49697730-416e3d80-fbbb-11e8-87c3-0e9f8d777aba.png)


Risolve: #301 

## Tipologia

- [x] Nuova funzionalità (cambiamenti minori che aggiungono una nuova funzionalità)
- [x] Cambiamento maggiore (fix o funzionalità che richiede una revisione prima di essere pubblicata)

# Checklist

- [x] Il codice segue le linee guida del progetto
- [x] Ho commentato il codice, in particolare nelle parti più complesse
- [x] Ho aggiornato di conseguenza la documentazione (se presente)
- [x] Il codice non genera warnings

# Status

- [x] Implementazione sulle fatture di vendita
- [ ] Implementazione sui preventivi