### PR TITLE
Modifica richiamo funzione generazione immagine errata

### DIFF
--- a/modules/interventi/actions.php
+++ b/modules/interventi/actions.php
@@ -489,7 +489,7 @@ switch (post('op')) {
 
                 $data = explode(',', post('firma_base64'));
 
-                $img = Intervention\Image\ImageManagerStatic::build(base64_decode($data[1]));
+                $img = Intervention\Image\ImageManagerStatic::make(base64_decode($data[1]));
                 $img->resize(680, 202, function ($constraint) {
                     $constraint->aspectRatio();
                 });


### PR DESCRIPTION
## Descrizione

C'era un problema durante la generazione dell'immagine della firma degli interventi.
Mi restituiva l'errore che veniva richiamato un metodo build inesistente.
Ho trovato il metodo corretto e ho corretto la funzione.

## Tipologia

- [x] Bug fix (cambiamenti minori che risolvono una issue)
- [ ] Nuova funzionalità (cambiamenti minori che aggiungono una nuova funzionalità)
- [ ] Cambiamento maggiore (fix o funzionalità che richiede una revisione prima di essere pubblicata)
- [ ] Questo cambiamenti richiede un aggiornamento della documentazione

# Checklist

- [x] Il codice segue le linee guida del progetto
- [ ] Ho commentato il codice, in particolare nelle parti più complesse
- [ ] Ho aggiornato di conseguenza la documentazione (se presente)
- [x] Il codice non genera warnings
