### PR TITLE
Fix al calcolo seriali

### DIFF
--- a/modules/articoli/actions.php
+++ b/modules/articoli/actions.php
@@ -151,7 +151,7 @@ switch (post('op')) {
         preg_match("/(.*?)([\d]*$)/", $serial__end, $m);
         $serial_end = intval($m[2]);
         $n_serial = abs($serial_end - $serial_start) + 1;
-        $serial_prefix = str_replace($serial_end, '', $serial__end);
+        $serial_prefix = rtrim($serial__end,$serial_end);
         $serial_pad_length = strlen($serial__end) - strlen($serial_prefix);
 
         // Altro


### PR DESCRIPTION
## Descrizione

Ho notato durante l'inserimento di un seriale che il calcolo rimuove tutti i caratteri presenti nella stringa corrispondenti alla variabile $serial_end, ma se questa è presente in quello che è diventa il prefisso viene sostituita anche qui. Esempio: seriale CYC2020YQ0, $serial_end = 0, prefisso dovrebbe essere CYC2020YQ, invece diventa CYC22YQ inserendo nel DB il seriale errato.
Con la modifica che ho effettuato tolgo solo l'ultima occorrenza della variabile $serial_end dalla variabile $serial__end così da avere il prefisso corretto.

## Tipologia

- [x] Bug fix (cambiamenti minori che risolvono una issue)
- [ ] Nuova funzionalità (cambiamenti minori che aggiungono una nuova funzionalità)
- [ ] Cambiamento maggiore (fix o funzionalità che richiede una revisione prima di essere pubblicata)
- [ ] Questo cambiamenti richiede un aggiornamento della documentazione

# Checklist

- [x] Il codice segue le linee guida del progetto
- [ ] Ho commentato il codice, in particolare nelle parti più complesse
- [ ] Ho aggiornato di conseguenza la documentazione (se presente)
- [x] Il codice non genera warnings
