### PR TITLE
Fix per php7.3 dove preg_quote aggiunge il backslash anche al carattere #

### DIFF
--- a/src/Util/Generator.php
+++ b/src/Util/Generator.php
@@ -100,7 +100,7 @@ class Generator
         $values = array_column($replaces, 'regex');
 
         $pattern = preg_replace('/#{1,}/', '#', $pattern);
-        $pattern = preg_quote($pattern, '/');
+        $pattern = str_replace('\\#','#',preg_quote($pattern, '/'));
         $pattern = str_replace(array_keys($replaces), array_values($values), $pattern);
 
         // Individuazione dei valori


### PR DESCRIPTION

## Descrizione

Dalla versione 7.3 di PHP la funzione preg_quote aggiunge un backslash anche al carattere #.
Questo scombina tutte le creazioni delle numerazioni perchè scombina l'espressione regolare di match dei dati del numero documento su qualsiasi documento.
Ho aggiunto la funzione str_replace dopo preg_quote in maniera da togliere questi backslash di troppo.

## Tipologia

- [X] Bug fix

# Checklist

- [X] Il codice segue le linee guida del progetto
- [X] Il codice non genera warnings
