### PR TITLE
Soluzione bug tooltips nel modulo dashboard #666

### DIFF
--- a/modules/dashboard/actions.php
+++ b/modules/dashboard/actions.php
@@ -85,7 +85,7 @@ switch (get('op')) {
             }
 
             // Lettura dati intervento
-            $query = 'SELECT *, in_interventi.codice, idstatointervento AS parent_idstato, idtipointervento AS parent_idtipo, (SELECT descrizione FROM in_statiintervento WHERE idstatointervento=parent_idstato) AS stato, (SELECT descrizione FROM in_tipiintervento WHERE idtipointervento=parent_idtipo) AS tipo, (SELECT nomesede FROM an_sedi WHERE id=idsede) AS sede, (SELECT idzona FROM an_anagrafiche WHERE idanagrafica=in_interventi.idanagrafica) AS idzona FROM in_interventi LEFT JOIN an_anagrafiche ON in_interventi.idanagrafica=an_anagrafiche.idanagrafica WHERE in_interventi.id='.prepare($id).' '.Modules::getAdditionalsQuery('Interventi');
+            $query = 'SELECT *, in_interventi.codice, idstatointervento AS parent_idstato, idtipointervento AS parent_idtipo, (SELECT descrizione FROM in_statiintervento WHERE idstatointervento=parent_idstato) AS stato, (SELECT descrizione FROM in_tipiintervento WHERE idtipointervento=parent_idtipo) AS tipo, (SELECT nomesede FROM an_sedi WHERE id=idsede_destinazione) AS sede, (SELECT idzona FROM an_anagrafiche WHERE idanagrafica=in_interventi.idanagrafica) AS idzona FROM in_interventi LEFT JOIN an_anagrafiche ON in_interventi.idanagrafica=an_anagrafiche.idanagrafica WHERE in_interventi.id='.prepare($id).' '.Modules::getAdditionalsQuery('Interventi');
             $rs = $dbo->fetchArray($query);
 
             $desc_tipointervento = $rs[0]['tipo'];

--- a/modules/dashboard/edit.php
+++ b/modules/dashboard/edit.php
@@ -706,6 +706,8 @@ if (setting('Utilizzare i tooltip sul calendario') == '1') {
 										trigger: 'hover',
 										position: 'left'
 									});
+                                    element.tooltipster('show');
+
 								}
 								else{
 									return false;


### PR DESCRIPTION
## Descrizione

Bugfix tooltips nel modulo dashboard causato da riferimento errato colonna mysql
Inoltre al primo passaggio sopra un'attività non visualizzava il tooltip

Risolve: #666

## Tipologia

- [ ] Bug fix 


