### PR TITLE
Fix issue devcode-it/openstamanager #789

### DIFF
--- a/modules/liste_newsletter/actions.php
+++ b/modules/liste_newsletter/actions.php
@@ -19,7 +19,7 @@ switch (filter('op')) {
 
         $query = filter('query');
         if (check_query($query)) {
-            $lista->query = $query;
+            $lista->query = html_entity_decode($query);
         }
 
         $lista->save();


### PR DESCRIPTION
## Descrizione

Il form html fa l'escaping dei caratteri come <> ecc; il DB non li interpreta correttamente se non vengono unescapati e quindi il campo delle query dinamiche del modulo fallisce in presenza di tali caratteri.

Risolve: #789 

## Tipologia

Rimuovi le opzioni non rilevanti.

- [x] Bug fix (cambiamenti minori che risolvono una issue)

# Checklist

- [x] Il codice segue le linee guida del progetto
- [x] Ho commentato il codice, in particolare nelle parti più complesse
- [x] Ho aggiornato di conseguenza la documentazione (se presente)
- [x] Il codice non genera warnings
