### PR TITLE
Fix PEC per variabili email

### DIFF
--- a/mail.php
+++ b/mail.php
@@ -25,11 +25,15 @@ $template = Template::find(get('id'));
 $module = $template->module;
 $smtp = $template->account;
 
-$body = $module->replacePlaceholders($id_record, $template['body']);
-$subject = $module->replacePlaceholders($id_record, $template['subject']);
+$placeholder_options = [
+    'is_pec' => intval($smtp['pec']),
+];
 
-$email = $module->replacePlaceholders($id_record, '{email}');
-$id_anagrafica = $module->replacePlaceholders($id_record, '{id_anagrafica}');
+$body = $module->replacePlaceholders($id_record, $template['body'], $placeholder_options);
+$subject = $module->replacePlaceholders($id_record, $template['subject'], $placeholder_options);
+
+$email = $module->replacePlaceholders($id_record, '{email}', $placeholder_options);
+$id_anagrafica = $module->replacePlaceholders($id_record, '{id_anagrafica}', $placeholder_options);
 
 // Campi mancanti
 $campi_mancanti = [];

--- a/modules/contratti/variables.php
+++ b/modules/contratti/variables.php
@@ -19,12 +19,15 @@
 
 $r = $dbo->fetchOne('SELECT *,
     an_anagrafiche.email,
+    an_anagrafiche.pec,
     an_anagrafiche.ragione_sociale
-FROM co_contratti INNER JOIN an_anagrafiche ON co_contratti.idanagrafica=an_anagrafiche.idanagrafica WHERE co_contratti.id='.prepare($id_record));
+FROM co_contratti
+    INNER JOIN an_anagrafiche ON co_contratti.idanagrafica=an_anagrafiche.idanagrafica
+WHERE co_contratti.id='.prepare($id_record));
 
 // Variabili da sostituire
 return [
-    'email' => $r['email'],
+    'email' => $options['is_pec'] ? $r['pec'] : $r['email'],
     'ragione_sociale' => $r['ragione_sociale'],
     'numero' => $r['numero'],
     'descrizione' => $r['descrizione'],

--- a/modules/ddt/variables.php
+++ b/modules/ddt/variables.php
@@ -17,13 +17,16 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-$r = $dbo->fetchOne('SELECT *,
-    (SELECT email FROM an_anagrafiche WHERE an_anagrafiche.idanagrafica=dt_ddt.idanagrafica) AS email
-FROM dt_ddt WHERE id='.prepare($id_record));
+$r = $dbo->fetchOne('SELECT dt_ddt.*,
+    an_anagrafiche.email,
+    an_anagrafiche.pec
+FROM dt_ddt
+    INNER JOIN an_anagrafiche ON dt_ddt.idanagrafica = an_anagrafiche.idanagrafica
+WHERE id='.prepare($id_record));
 
 // Variabili da sostituire
 return [
-    'email' => $r['email'],
+    'email' => $options['is_pec'] ? $r['pec'] : $r['email'],
     'numero' => empty($r['numero_esterno']) ? $r['numero'] : $r['numero_esterno'],
     'note' => $r['note'],
     'data' => Translator::dateToLocale($r['data']),

--- a/modules/emails/src/Mail.php
+++ b/modules/emails/src/Mail.php
@@ -159,7 +159,7 @@ class Mail extends Model
         if (isset($this->template)) {
             $module = $this->template->module;
 
-            $value = $module->replacePlaceholders($this->id_record, $value);
+            $value = $module->replacePlaceholders($this->id_record, $value, ['is_pec' => intval($this->account->pec)]);
         }
 
         $this->attributes['subject'] = $value;
@@ -170,7 +170,7 @@ class Mail extends Model
         if (isset($this->template)) {
             $module = $this->template->module;
 
-            $value = $module->replacePlaceholders($this->id_record, $value);
+            $value = $module->replacePlaceholders($this->id_record, $value, ['is_pec' => intval($this->account->pec)]);
         }
 
         $this->attributes['content'] = $value;

--- a/modules/fatture/variables.php
+++ b/modules/fatture/variables.php
@@ -19,15 +19,14 @@
 
 $r = $dbo->fetchOne('SELECT co_documenti.*,
 	an_anagrafiche.email,
+    an_anagrafiche.pec,
     an_anagrafiche.idconto_cliente,
     an_anagrafiche.idconto_fornitore,
-	an_anagrafiche.pec,
 	an_anagrafiche.ragione_sociale,
-	co_tipidocumento.descrizione AS tipo_documento,
-	(SELECT pec FROM em_accounts WHERE em_accounts.id='.prepare($template['id_account']).') AS is_pec
+	co_tipidocumento.descrizione AS tipo_documento
 FROM co_documenti
-    INNER JOIN an_anagrafiche ON co_documenti.idanagrafica=an_anagrafiche.idanagrafica
-    INNER JOIN co_tipidocumento ON co_tipidocumento.id=co_documenti.idtipodocumento
+    INNER JOIN an_anagrafiche ON co_documenti.idanagrafica = an_anagrafiche.idanagrafica
+    INNER JOIN co_tipidocumento ON co_tipidocumento.id = co_documenti.idtipodocumento
 WHERE co_documenti.id='.prepare($id_record));
 
 if (!empty(setting('Logo stampe'))) {
@@ -53,7 +52,7 @@ $r_company = $dbo->fetchOne('SELECT * FROM an_anagrafiche WHERE idanagrafica='.p
 
 // Variabili da sostituire
 return [
-    'email' => $r['is_pec'] ? $r['pec'] : $r['email'],
+    'email' => $options['is_pec'] ? $r['pec'] : $r['email'],
     'id_anagrafica' => $r['idanagrafica'],
     'ragione_sociale' => $r['ragione_sociale'],
     'numero' => empty($r['numero_esterno']) ? $r['numero'] : $r['numero_esterno'],

--- a/modules/interventi/variables.php
+++ b/modules/interventi/variables.php
@@ -18,14 +18,17 @@
  */
 
 $r = $dbo->fetchOne('SELECT *,
+    an_anagrafiche.email,
+    an_anagrafiche.pec,
     (SELECT MAX(orario_fine) FROM in_interventi_tecnici WHERE idintervento=in_interventi.id) AS data_fine,
-    (SELECT email FROM an_anagrafiche WHERE an_anagrafiche.idanagrafica=in_interventi.idanagrafica) AS email,
     (SELECT descrizione FROM in_statiintervento WHERE idstatointervento=in_interventi.idstatointervento) AS stato
-FROM in_interventi WHERE id='.prepare($id_record));
+FROM in_interventi
+    INNER JOIN an_anagrafiche ON in_interventi.idanagrafica = an_anagrafiche.idanagrafica
+WHERE id='.prepare($id_record));
 
 // Variabili da sostituire
 return [
-    'email' => $r['email'],
+    'email' => $options['is_pec'] ? $r['pec'] : $r['email'],
     'numero' => $r['codice'],
     'richiesta' => $r['richiesta'],
     'descrizione' => $r['descrizione'],

--- a/modules/ordini/variables.php
+++ b/modules/ordini/variables.php
@@ -17,13 +17,16 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-$r = $dbo->fetchOne('SELECT *,
-    (SELECT email FROM an_anagrafiche WHERE an_anagrafiche.idanagrafica=or_ordini.idanagrafica) AS email
-FROM or_ordini WHERE id='.prepare($id_record));
+$r = $dbo->fetchOne('SELECT or_ordini.*,
+    an_anagrafiche.email,
+    an_anagrafiche.pec
+FROM or_ordini
+    INNER JOIN an_anagrafiche ON or_ordini.idanagrafica = an_anagrafiche.idanagrafica
+WHERE id='.prepare($id_record));
 
 // Variabili da sostituire
 return [
-    'email' => $r['email'],
+    'email' => $options['is_pec'] ? $r['pec'] : $r['email'],
     'id_anagrafica' => $r['idanagrafica'],
     'numero' => empty($r['numero_esterno']) ? $r['numero'] : $r['numero_esterno'],
     'note' => $r['note'],

--- a/modules/preventivi/variables.php
+++ b/modules/preventivi/variables.php
@@ -26,7 +26,7 @@ $revisione = $dbo->fetchNum('SELECT * FROM co_preventivi WHERE master_revision =
 
 // Variabili da sostituire
 return [
-    'email' => $r['email'],
+    'email' => $options['is_pec'] ? $r['pec'] : $r['email'],
     'numero' => $r['numero'],
     'ragione_sociale' => $r['ragione_sociale'],
     'descrizione' => $r['descrizione'],

--- a/modules/scadenzario/variables.php
+++ b/modules/scadenzario/variables.php
@@ -26,14 +26,14 @@ $r = $dbo->fetchOne('SELECT co_scadenziario.*, co_documenti.*,
 	(SELECT descrizione FROM co_pagamenti WHERE co_pagamenti.id = co_documenti.idpagamento) AS pagamento
 FROM co_scadenziario
     INNER JOIN co_documenti ON co_documenti.id = co_scadenziario.iddocumento
-    INNER JOIN an_anagrafiche ON co_documenti.idanagrafica=an_anagrafiche.idanagrafica
+    INNER JOIN an_anagrafiche ON co_documenti.idanagrafica = an_anagrafiche.idanagrafica
 WHERE co_scadenziario.pagato != co_scadenziario.da_pagare AND co_scadenziario.iddocumento = (SELECT iddocumento FROM co_scadenziario s WHERE id='.prepare($id_record).')');
 
 $logo_azienda = str_replace(base_dir(), base_path(), App::filepath('templates/base|custom|/logo_azienda.jpg'));
 
 // Variabili da sostituire
 return [
-    'email' => $r['is_pec'] ? $r['pec'] : $r['email'],
+    'email' => $options['is_pec'] ? $r['pec'] : $r['email'],
     'id_anagrafica' => $r['idanagrafica'],
     'ragione_sociale' => $r['ragione_sociale'],
     'numero' => empty($r['numero_esterno']) ? $r['numero'] : $r['numero_esterno'],

--- a/src/Models/Module.php
+++ b/src/Models/Module.php
@@ -55,16 +55,16 @@ class Module extends Model
         'options2',
     ];
 
-    public function replacePlaceholders($id_record, $value)
+    public function replacePlaceholders($id_record, $value, $options = [])
     {
-        $replaces = $this->getPlaceholders($id_record);
+        $replaces = $this->getPlaceholders($id_record, $options);
 
         $value = str_replace(array_keys($replaces), array_values($replaces), $value);
 
         return $value;
     }
 
-    public function getPlaceholders($id_record)
+    public function getPlaceholders($id_record, $options = [])
     {
         if (!isset($this->variables[$id_record])) {
             $dbo = $database = database();


### PR DESCRIPTION
## Descrizione

Grazie alla segnalazione di un utente sul forum, si è verificato che l'auto-completamento della PEC nelle mail al posto dell'email predefinita non funziona correttamente da alcune versioni.
Forum: https://forum.openstamanager.com/viewtopic.php?p=104645#p104645

La modifica introduce delle opzioni per il metodo getPlaceholders, che permette di definire in modo statico alcune variabili di interesse.

## Tipologia

Rimuovi le opzioni non rilevanti.

- [x] Bug fix (cambiamenti minori che risolvono una issue)

