### PR TITLE
Fix vulnerabilità su client IP

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -202,7 +202,7 @@ function get_client_ip()
         $ipaddress = 'UNKNOWN';
     }
 
-    return $ipaddress;
+    return strip_tags($ipaddress);
 }
 
 /**


### PR DESCRIPTION
Risolve una vulnerabilità per cui un utente senza privilegi di accesso può iniettare codice HTML (fino a 15 caratteri fortunatamente) come indirizzo IP nella schermata dei log di accesso.