### PR TITLE
Aggiunto task "gulp watch" per aggiornare automaticamente CSS, JS e immagini

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -506,7 +506,10 @@ exports.default = bower;
 // Watch task - lanciato con `gulp watch`, resta in attesa e ogni volta che viene modificato un asset in src
 // viene aggiornata la dist
 gulp.task('watch', function () {
+    gulp.watch('assets/src/css/*.css', gulp.series(srcCSS, CSS));
+    gulp.watch('assets/src/css/print/*.css', gulp.series(srcCSS, CSS));
     gulp.watch('assets/src/css/themes/*.css', gulp.series(srcCSS, CSS));
-    gulp.watch('assets/src/js/modules/*.js', gulp.series(srcJS, JS));
+    gulp.watch('assets/src/js/base/*.js', gulp.series(srcJS, JS));
+    gulp.watch('assets/src/js/functions/*.js', gulp.series(srcJS, JS));
     gulp.watch('assets/src/img/*', gulp.series(images));
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -502,3 +502,11 @@ exports.srcCSS = srcCSS;
 exports.bower = bower;
 exports.release = release;
 exports.default = bower;
+
+// Watch task - lanciato con `gulp watch`, resta in attesa e ogni volta che viene modificato un asset in src
+// viene aggiornata la dist
+gulp.task('watch', function () {
+    gulp.watch('assets/src/css/themes/*.css', gulp.series(srcCSS, CSS));
+    gulp.watch('assets/src/js/modules/*.js', gulp.series(srcJS, JS));
+    gulp.watch('assets/src/img/*', gulp.series(images));
+});


### PR DESCRIPTION
## Descrizione

Ho aggiunto un semplice task nel `gulpfile.js`. Lanciato con `gulp watch` resta in attesa, e quando viene modificato un asset nella directory `assets/src` aggiorna immediatamente la dist

Rimuovi le opzioni non rilevanti.

- [x] Nuova funzionalità (cambiamenti minori che aggiungono una nuova funzionalità)
- [x] Questo cambiamenti potrebbe richiedere un aggiornamento della documentazione

# Checklist

- [x] Il codice segue le linee guida del progetto
- [x] Ho commentato il codice, in particolare nelle parti più complesse
- [x] Ho aggiornato di conseguenza la documentazione (se presente)
- [x] Il codice non genera warnings
