### PR TITLE
fixed issue 1053

### DIFF
--- a/plugins/importFE/actions.php
+++ b/plugins/importFE/actions.php
@@ -306,13 +306,12 @@ switch (filter('op')) {
         // Riorganizzazione dati ordini per numero di riga
         $dati_ordini = [];
         foreach ($DatiOrdini as $dato) {
-            foreach ($dato['RiferimentoNumeroLinea'] as $dati => $linea) {
+            $linea = $dato['RiferimentoNumeroLinea'];
                 foreach ($replaces as $replace) {
                     if(string_starts_with($dato['IdDocumento'], $replace)) {
                         $dato['IdDocumento'] = str_replace($replace, '', $dato['IdDocumento']);
                         break;
                     }
-                }
                 $dati_ordini[(int)$linea] = [
                     'numero' => $dato['IdDocumento'],
                     'anno' => ( new Carbon($dato['Data']) )->format('Y'),
@@ -320,16 +319,15 @@ switch (filter('op')) {
             }
         }
 
-        // Riorganizzazione dati ordini per numero di riga
+        // Riorganizzazione dati ddt per numero di riga
         $dati_ddt = [];
         foreach ($DatiDDT as $dato) {
-            foreach ($dato['RiferimentoNumeroLinea'] as $dati => $linea) {
+            $linea = $dato['RiferimentoNumeroLinea'];
                 foreach ($replaces as $replace) {
                     if(string_starts_with($dato['NumeroDDT'], $replace)) {
                         $dato['NumeroDDT'] = str_replace($replace, '', $dato['NumeroDDT']);
                         break;
                     }
-                }
                 $dati_ddt[(int)$linea] = [
                     'numero' => $dato['NumeroDDT'],
                     'anno' => ( new Carbon($dato['DataDDT']) )->format('Y'),


### PR DESCRIPTION
Import FE non setta correttamente i riferimenti a DDT presenti nel file xml

## Descrizione

Quando si importa una fattura elettronica in acquisto, cliccando sul bottone "Cerca riferimenti" dovrebbero essere cercati per primi i riferimenti nelle ddt indicate nel file xml che si sta importando.
Lo stesso per eventuali ordini fornitore
Le DDT e gli ordini indicati nel file xml venivano ignorati

Questo commit risolve il problema

Risolve: #1053 

## Tipologia

Rimuovi le opzioni non rilevanti.

- [x] Bug fix (cambiamenti minori che risolvono una issue)
- [ ] Nuova funzionalità (cambiamenti minori che aggiungono una nuova funzionalità)
- [ ] Cambiamento maggiore (fix o funzionalità che richiede una revisione prima di essere pubblicata)
- [ ] Questo cambiamenti richiede un aggiornamento della documentazione

# Checklist

- [x] Il codice segue le linee guida del progetto
- [ ] Ho commentato il codice, in particolare nelle parti più complesse
- [ ] Ho aggiornato di conseguenza la documentazione (se presente)
- [x] Il codice non genera warnings
