### PR TITLE
Fix: fatture con tante righe diventano molto lente

### DIFF
--- a/plugins/registrazioni/edit.php
+++ b/plugins/registrazioni/edit.php
@@ -54,6 +54,7 @@ echo '
 
     // Righe documento
     if (!empty($fattura)) {
+        $optionsConti = AJAX::select($conti, [], null, 0, 10000);
         $righe = $fattura->getRighe();
         $num = 0;
         foreach ($righe as $riga) {
@@ -107,7 +108,7 @@ echo '
                     </td>
 
                     <td>
-                        {[ "type": "select", "name": "idconto['.$riga['id'].']", "required": 1, "value": "'.$riga->id_conto.'", "ajax-source": "'.$conti.'", "class": "unblockable" ]}
+                        {[ "type": "select", "name": "idconto['.$riga['id'].']", "required": 1, "value": "'.$riga->id_conto.'", "values": ' . json_encode($optionsConti['results']) . ', "class": "unblockable" ]}
                     </td>
                 </tr>';
             }
@@ -149,4 +150,3 @@ function copy() {
     }
 }
 </script>';
-    


### PR DESCRIPTION
## Descrizione

Velocizza l'apertura della pagina delle fatture quando sono presenti molte righe. Nei miei test per fatture da ~400 righe si passa da 30 secondi a 5.

## Tipologia

- [x] Bug fix (cambiamenti minori che risolvono una issue)

# Checklist

- [x] Il codice segue le linee guida del progetto
- [x] Il codice non genera warnings
