### PR TITLE
Gestire l'obbligatorietà del campo BIC in gestione banche

### DIFF
--- a/modules/banche/add.php
+++ b/modules/banche/add.php
@@ -76,6 +76,7 @@ echo '
     var branch_code = input("branch_code");
     var bank_code = input("bank_code");
     var id_nazione = input("id_nazione");
+    var bic = input("bic");
 
     var components = [branch_code, bank_code, id_nazione];
 
@@ -117,6 +118,12 @@ echo '
             dataType: "json",
             success: function (response) {
                 compilaCampi(response);
+
+                if (response.id_nazione.text === "Italia"){
+                    bic.setRequired(false);
+                } else {
+                    bic.setRequired(true);
+                }
             },
             error: function() {
                 toastr["error"]("<?php echo tr('Formato IBAN non valido'); ?>");

--- a/modules/banche/edit.php
+++ b/modules/banche/edit.php
@@ -60,7 +60,7 @@ include_once __DIR__.'/../../core.php';
                 </div>
 
                 <div class="col-md-4">
-                    {[ "type": "text", "label": "<?php echo tr('BIC'); ?>", "name": "bic", "required": "1", "class": "alphanumeric-mask", "minlength": 8, "maxlength": 11, "value": "$bic$", "help": "<?php echo $help_codice_bic; ?>" ]}
+                    {[ "type": "text", "label": "<?php echo tr('BIC'); ?>", "name": "bic", "class": "alphanumeric-mask", "minlength": 8, "maxlength": 11, "value": "$bic$", "help": "<?php echo $help_codice_bic; ?>" ]}
                 </div>
             </div>
 

--- a/modules/banche/edit.php
+++ b/modules/banche/edit.php
@@ -149,6 +149,7 @@ if (!empty($numero_documenti)) {
     var check_digits = input("check_digits");
     var national_check_digits = input("national_check_digits");
     var id_nazione = input("id_nazione");
+    var bic = input("bic");
 
     var components = [branch_code, bank_code, account_number, check_digits, national_check_digits, id_nazione];
 
@@ -190,6 +191,12 @@ if (!empty($numero_documenti)) {
             dataType: "json",
             success: function (response) {
                 compilaCampi(response);
+
+                if (response.id_nazione.text === "Italia"){
+                    bic.setRequired(false);
+                } else {
+                    bic.setRequired(true);
+                }
             },
             error: function() {
                 toastr["error"]("<?php echo tr('Formato IBAN non valido'); ?>");


### PR DESCRIPTION
## Descrizione

Come da oggetto, gestisce l'obbligatorietà del campo BIC in gestione banche. Se l'IBAN appartiene ad un conto italiano il BIC non è required, altrimenti lo è.

Risolve: #1035

## Tipologia

Rimuovi le opzioni non rilevanti.

- [x] Bug fix (cambiamenti minori che risolvono una issue)

# Checklist

- [x] Il codice segue le linee guida del progetto
- [x] Il codice non genera warnings
