### PR TITLE
Modifiche all'invio delle email: mittente e reply_to

### DIFF
--- a/config.example.php
+++ b/config.example.php
@@ -65,3 +65,12 @@ $assets = [
     'print' => [],
     'js' => [],
 ];
+
+// Indica se i messaggi di posta elettronica devono essere inviati con
+// l'istruzione reply_to impostata con l'indirizzo email dell'utente collegato
+$force_reply_to_sender = false;
+
+// Indica se i messaggi di posta elettronica devono essere inviati con l'account di posta elettronica
+// corrispondente all'indirizzo email dell'utente collegato. Se non c'è un account con questo indirizzo
+// email, verrà utilizzato l'account di default.
+$force_mail_from_sender = false;

--- a/mail.php
+++ b/mail.php
@@ -35,7 +35,7 @@ $subject = $module->replacePlaceholders($id_record, $template['subject'], $place
 $emails = [];
 if ($module->replacePlaceholders($id_record, '{email}')) {
     $emails = explode(';', $module->replacePlaceholders($id_record, '{email}', $placeholder_options));
-} 
+}
 
 $id_anagrafica = $module->replacePlaceholders($id_record, '{id_anagrafica}', $placeholder_options);
 
@@ -58,7 +58,7 @@ if ($template->name  == 'Notifica intervento'){
         $anagrafica = $dbo->table('an_anagrafiche')->where('idanagrafica', $tecnico['id_tecnico'])->where('email', '!=', '')->first();
         if (!in_array($anagrafica->email, $emails)) {
             $emails[] = $anagrafica->email;
-        }   
+        }
     }
 }
 
@@ -94,9 +94,37 @@ echo '
 	<input type="hidden" name="id_module" value="'.$id_module.'">
 	<input type="hidden" name="id_record" value="'.$id_record.'">
 
-    <input type="hidden" name="template" value="'.$template['id'].'">
+    <input type="hidden" name="template" value="'.$template['id'].'">';
 
-    <p><b>'.tr('Mittente').'</b>: '.$smtp['from_name'].' &lt;'.$smtp['from_address'].'&gt;</p>';
+$from_name = $smtp['from_name'];
+$from_address = $smtp['from_address'];
+$reply_to_address = '';
+
+if (!empty($config['force_reply_to_sender']) && $config['force_reply_to_sender'] === true) {
+    $user = \Auth::user();
+    $from_name = $user->username;
+    $from_address = $smtp['from_address'];
+    $reply_to_address = $user->email;
+}
+
+if (isset($config['force_mail_from_sender']) && $config['force_mail_from_sender'] === true) {
+    $user = \Auth::user();
+    $email = $user->email;
+    $reply_to_address = '';
+    $account = Modules\Emails\Account::where('username', $email)->first();
+    if (!empty($account)) {
+        $from_name = $account->from_name;
+        $from_address = $account->from_address;
+        $reply_to_address = '';
+    }
+}
+
+echo '<p><b>' . tr('Mittente') . '</b>: ';
+echo $from_name . ' &lt;' . $from_address . '&gt;</p>';
+if ($reply_to_address !== '') {
+    echo '<p><b>' . tr('Indirizzo per le risposte') . '</b>: ';
+    echo ' &lt;' . $reply_to_address . '&gt;</p>';
+}
 
 if (!empty($template['cc'])) {
     echo '
@@ -180,7 +208,7 @@ echo '
                 'id' => 'body_'.rand(0, 999),
                 'value' => $body,
             ]);
-					
+
             echo'
             </div>
     </div>';

--- a/src/Notifications/EmailNotification.php
+++ b/src/Notifications/EmailNotification.php
@@ -40,11 +40,27 @@ class EmailNotification extends PHPMailer implements NotificationInterface
         parent::__construct($exceptions);
 
         $this->CharSet = 'UTF-8';
+        $config = \App::getConfig();
 
         // Configurazione di base
         $account = $account instanceof Account ? $account : Account::find($account);
         if (empty($account)) {
             $account = Account::where('predefined', true)->first();
+        }
+
+        if (isset($config['force_reply_to_sender']) && $config['force_reply_to_sender'] === true) {
+            $user = \Auth::user();
+            $account['from_name'] = $user->username;
+            $this->AddReplyTo($user->email, $user->nome);
+        }
+
+        if (isset($config['force_mail_from_sender']) && $config['force_mail_from_sender'] === true) {
+            $user = \Auth::user();
+            $email = $user->email;
+            $account_data = Account::where('username', $email)->first();
+            if (!empty($account_data)) {
+                $account = $account_data;
+            }
         }
 
         // Preparazione email


### PR DESCRIPTION
## Descrizione

Con questa PR si aggiungono due piccole funzionalità all'invio delle email, entrambi gestibili da file di configurazione:
- `$force_reply_to_sender` (false | true). Se true ogni email partirà con il reply_to impostato all'indirizzo email dell'account che sta inviando la mail
- `$force_mail_from_sender` (false | true). Se true, per ogni invio email viene controllato se esiste un account SMTP configurato con la stessa email dell'account che sta inviando la mail. Se esiste verrà usato quell'SMTP, altrimenti verrà usato l'account SMTP di default.

Le nuove variabili sono illustrate in config.example.com. Il default è false in entrambi i casi, per mantenere il comportamento attuale, anche qualora le variabili non fossero impostate nel file di configurazione.

## Tipologia

Rimuovi le opzioni non rilevanti.

- [x] Nuova funzionalità (cambiamenti minori che aggiungono una nuova funzionalità)
- [x] Questo cambiamenti richiede un aggiornamento della documentazione

# Checklist

- [x] Il codice segue le linee guida del progetto
- [x] Ho commentato il codice, in particolare nelle parti più complesse
- [x] Il codice non genera warnings
