### PR TITLE
Gestione articoli concatenati

### DIFF
--- a/migration.sql
+++ b/migration.sql
@@ -1,0 +1,14 @@
+INSERT INTO `zz_plugins` (`name`, `title`, `idmodule_from`, `idmodule_to`, `position`, `script`, `enabled`, `default`, `order`, `compatibility`, `version`, `options2`, `options`, `directory`, `help`, `created_at`, `updated_at`) VALUES
+('Articoli concatenati',	'Articoli concatenati',	21,	21,	'tab',	'articoli.concatenati.php',	1,	1,	0,	'',	'',	NULL,	NULL,	'',	'',	'2022-03-07 10:22:56',	'2022-03-07 10:22:56');
+
+CREATE TABLE `mg_articoli_concatenati` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `id_articolo` int(11) NOT NULL,
+  `id_articolo_concatenato` int(11) NOT NULL,
+  `prezzo` float NOT NULL DEFAULT 0,
+  `idiva` int(11) NOT NULL DEFAULT 0,
+  `prezzo_ivato` float NOT NULL DEFAULT 0,
+  `created_at` timestamp NOT NULL DEFAULT current_timestamp(),
+  `updated_at` timestamp NOT NULL DEFAULT current_timestamp(),
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;

--- a/modules/articoli/actions.php
+++ b/modules/articoli/actions.php
@@ -72,7 +72,7 @@ switch (post('op')) {
         $articolo->um = post('um');
         $articolo->um_secondaria = post('um_secondaria');
         $articolo->fattore_um_secondaria = post('fattore_um_secondaria');
-        
+
         $articolo->save();
 
         // Aggiornamento delle varianti per i campi comuni
@@ -244,7 +244,7 @@ switch (post('op')) {
     // Duplica articolo
     case 'copy':
         $new = $articolo->replicate();
-        
+
         //Se non specifico il codice articolo lo imposto uguale all'id della riga
         if (empty(post('codice'))) {
             $codice = $dbo->fetchOne('SELECT MAX(id) as codice FROM mg_articoli')['codice'] + 1;
@@ -406,6 +406,48 @@ switch (post('op')) {
                 'idsede' => $idsede_partenza,
             ]);
         }
+
+        break;
+
+    case 'add_concatenato':
+        $id_articolo = post('id_articolo');
+        $id_articolo_concatenato = post('id_articolo_concatenato');
+
+        $articolo = $dbo->fetchOne('SELECT prezzo_vendita, idiva_vendita FROM mg_articoli WHERE id='.prepare($id_articolo_concatenato));
+        $prezzo = floatval($articolo['prezzo_vendita']);
+
+        $iva = $dbo->fetchOne('SELECT percentuale FROM co_iva WHERE id='.prepare($articolo['idiva_vendita']))['percentuale'];
+        $iva = ($iva) ? $iva : 0;
+
+        $dbo->insert('mg_articoli_concatenati', [
+            'id_articolo' => $id_articolo,
+            'id_articolo_concatenato' => $id_articolo_concatenato,
+            'prezzo' => $prezzo,
+            'iva' => $iva,
+            'prezzo_ivato' => $prezzo + ($prezzo / 100 * $iva),
+        ]);
+
+        break;
+
+    case 'update_concatenato':
+        $id = post('id');
+        $iva = post('iva');
+        $prezzo = post('prezzo');
+
+        $dbo->update('mg_articoli_concatenati', [
+            'prezzo' => $prezzo,
+            'iva' => $iva,
+            'prezzo_ivato' => $prezzo + ($prezzo / 100 * $iva),
+        ], [
+            'id' => $id,
+        ]);
+
+        break;
+
+    case 'remove_concatenato':
+        $id = post('id');
+
+        $dbo->query('DELETE FROM mg_articoli_concatenati WHERE id='.prepare($id));
 
         break;
 }

--- a/modules/articoli/plugins/articoli.concatenati.edit.php
+++ b/modules/articoli/plugins/articoli.concatenati.edit.php
@@ -1,0 +1,63 @@
+<?php
+/*
+ * OpenSTAManager: il software gestionale open source per l'assistenza tecnica e la fatturazione
+ * Copyright (C) DevCode s.r.l.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+include_once __DIR__.'/../../../core.php';
+
+$articolo_concatenato = $dbo->fetchOne('SELECT * FROM mg_articoli_concatenati WHERE id = '.prepare($_GET['id']));
+
+echo '
+<input type="hidden" id="id" value="'.$articolo_concatenato['id'].'">
+<div class="row">
+    <div id="prezzo" class="col-md-6">
+        {[ "type": "number", "label": "'.tr('Prezzo').'", "name": "prezzo", "value": "'.$articolo_concatenato['prezzo'].'", "icon-after": "'.currency().'" ]}
+    </div>';
+
+echo '
+</div>
+
+<div class="row">
+    <div class="col-md-12">
+        <button class="btn btn-primary pull-right btn-save">
+            <i class="fa fa-edit"></i> '.tr('Salva').'
+        </button>
+    </div>
+</div>';
+
+echo '
+<script>
+    $(document).ready(function(){
+        $("body").on("click", ".btn-save", function(){
+            $.ajax({
+                url: "'.$rootdir.'/modules/articoli/actions.php",
+                type: "post",
+                data: {
+                    op: "update_concatenato",
+                    prezzo: $("#prezzo").find("input").val(),
+                    id: $("#id").val(),
+                },
+                success: function(data){
+                    //reload page
+                    setTimeout(function(){
+                        location.reload();
+                    }, 1000);
+                },
+            });
+        });
+    });
+</script>';

--- a/modules/articoli/plugins/articoli.concatenati.php
+++ b/modules/articoli/plugins/articoli.concatenati.php
@@ -1,0 +1,135 @@
+<?php
+/*
+ * OpenSTAManager: il software gestionale open source per l'assistenza tecnica e la fatturazione
+ * Copyright (C) DevCode s.r.l.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+include_once __DIR__.'/../../../core.php';
+
+//get articoli concatenati by id_record
+$concatenati = $dbo->fetchArray(
+    'SELECT mg_articoli_concatenati.*, mg_articoli.descrizione AS descrizione_concatenato
+    FROM mg_articoli_concatenati
+    JOIN mg_articoli ON mg_articoli.id=mg_articoli_concatenati.id_articolo_concatenato
+    WHERE id_articolo='.prepare($id_record)
+);
+
+
+echo '
+<div class="row">
+    <div class="col-md-5">
+        {[ "type":"select", "id":"select-articolo", "label":"'.tr('Articolo').'", "ajax-source": "articoli" ]}
+    </div>
+
+    <div class="col-md-1">
+        <div class="btn-group btn-group-flex">
+            <button type="button" class="btn btn-primary" style="margin-top:25px;" onclick="aggiungiArticolo(this)">
+                <i class="fa fa-plus"></i> '.tr('Aggiungi').'
+            </button>
+        </div>
+    </div>
+</div>
+
+<table class="table table-hover table-condensed table-bordered" id="tbl-concatenati">
+    <thead>
+        <tr>
+            <th class="text-center" width="100">'.tr('Cod. articolo concatenato').'</th>
+            <th class="text-center" width="450">'.tr('Descrizone articolo concatenato').'</th>
+            <th class="text-center" width="95">'.tr('Prezzo').'</th>
+            <th class="text-center" width="95">'.tr('Prezzo ivato').'</th>
+            <th class="text-center" width="40"></th>
+        </tr>
+    </thead>
+    <tbody>';
+        foreach($concatenati as $concatenato) {
+            echo '
+            <tr>
+                <td><a href="'.base_path().'/controller.php?id_module='.$id_module.'&id_record='.$concatenato['id_articolo_concatenato'].'" target="_blank">'.$concatenato['id_articolo_concatenato'].'</a></td>
+                <td>'.$concatenato['descrizione_concatenato'].'</td>
+                <td class="text-right">'.moneyFormat($concatenato['prezzo']).'</td>
+                <td class="text-right">'.moneyFormat($concatenato['prezzo_ivato']).'</td>
+                <td class="text-center">
+                    <div class="input-group-btn">
+                        <a class="btn btn-xs btn-warning" title="'.tr('Modifica riga').'" onclick="modificaRiga(\''.$concatenato['id'].'\')">
+                            <i class="fa fa-edit"></i>
+                        </a>
+
+                        <a class="btn btn-xs btn-danger" title="'.tr('Rimuovi riga').'" onclick="rimuoviRiga(\''.$concatenato['id'].'\')">
+                            <i class="fa fa-trash"></i>
+                        </a>
+                    </div>
+                </td>
+            </tr>';
+        }
+    echo '
+    </tbody>
+</table>
+
+<!--<div class="btn-group">
+    <button type="button" class="btn btn-xs btn-default disabled" id="elimina_righe" onclick="rimuoviArticolo(getSelectData());">
+        <i class="fa fa-trash"></i>
+    </button>
+</div>-->
+
+
+<script>
+	async function aggiungiArticolo(button) {
+		id_articolo = $("#select-articolo").val();
+
+        $.ajax({
+            url: "'.$rootdir.'/modules/articoli/actions.php",
+            type: "post",
+            data: {
+                op: "add_concatenato",
+                id_articolo: globals.id_record,
+                id_articolo_concatenato: id_articolo,
+            },
+            success: function(data){
+                location.reload();
+            },
+        });
+	}
+
+	async function modificaRiga(id) {
+        openModal("'.tr('Dettagli').'", "'.$rootdir.'/modules/articoli/plugins/articoli.concatenati.edit.php?id_module=" + globals.id_module + "&id_record=" + globals.id_record + "&id_plugin='.$id_plugin.'&id=" + id);
+	}
+
+    async function rimuoviRiga(id) {
+        swal({
+            title: "'.tr('Attenzione').'",
+            text: "'.tr('Sei sicuro di voler eliminare questa riga?').'",
+            type: "warning",
+            showCancelButton: true,
+            confirmButtonColor: "#DD6B55",
+            confirmButtonText: "'.tr('Sì').'",
+            cancelButtonText: "'.tr('No').'",
+        }).then((result) => { //click su si
+            $.ajax({
+                url: "'.$rootdir.'/modules/articoli/actions.php",
+                type: "post",
+                data: {
+                    op: "remove_concatenato",
+                    id: id,
+                },
+                success: function(data){
+                    location.reload();
+                },
+            });
+        }).catch((err) => { //click su no
+
+        });
+    }
+</script>';


### PR DESCRIPTION
## Descrizione

Creato il plugin per poter concatenare articoli tra loro. Il plugin è accessibile dalla sezione articoli. Andando ad inserire un articolo in un documento di vendita verrà anche inserito automatico i relativi articoli concatenati se presenti

![Schermata del 2023-03-22 10-56-07](https://user-images.githubusercontent.com/80101758/226867243-983cb67f-38a8-47ae-9883-bc97cd37297b.png)

Esempi di articoli concatenati:
- Caldaia con codice RAE
- Vite con bullone

## Tipologia

Rimuovi le opzioni non rilevanti.

- [x] Nuova funzionalità (cambiamenti minori che aggiungono una nuova funzionalità)
- [x] Questo cambiamenti richiede un aggiornamento della documentazione

# Checklist

- [x] Il codice segue le linee guida del progetto
- [x] Il codice non genera warnings
