### PR TITLE
Gestione minimi magazzino e inserimento articoli

### DIFF
--- a/include/common/barcode.php
+++ b/include/common/barcode.php
@@ -1,0 +1,699 @@
+<?php
+/*
+ * OpenSTAManager: il software gestionale open source per l'assistenza tecnica e la fatturazione
+ * Copyright (C) DevCode s.r.l.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+include_once __DIR__.'/../../core.php';
+
+$incorpora_iva = setting('Utilizza prezzi di vendita comprensivi di IVA');
+$intestazione_prezzo = ($options['dir'] == 'uscita' ? tr('Prezzo di acquisto') : ($incorpora_iva ? tr('Prezzo vendita ivato') : tr('Prezzo vendita imponibile')));
+
+// Articolo
+echo '
+<div class="row">
+    <div class="col-md-6">
+        {[ "type": "text", "label": "' . tr('Inserisci barcode manualmente') . '", "name": "barcode", "value": "", "icon-before": "<i class=\"fa fa-barcode\"></i>" ]}
+    </div>
+    <div class="col-md-6">
+        {[ "type": "file", "label": "' . tr('Inserisci file') . '", "id": "barcode_file", "name": "barcode_file", "value": "", "icon-before": "<i class=\"fa fa-file\"></i>", "multiple": true ]}
+    </div>
+</div>
+
+<div class="alert alert-info hidden" id="articolo-missing">
+    <i class="fa fa-exclamation-circle"></i> '.tr('Nessuna corrispondenza trovata!').'
+</div>
+
+<div class="alert alert-warning hidden" id="articolo-qta">
+    <i class="fa fa-warning"></i> '.tr('Articolo con quantità non sufficiente!').'
+</div>
+
+<div class="row">
+    <div class="col-md-12">
+        <table class="table table-stripped hide" id="articoli_barcode">
+            <tr>
+                <th>'.tr('Articolo').'</th>
+                <th width="25%" class="text-center">'.$intestazione_prezzo.'</th>
+                <th width="20%" class="text-center">'.tr('Sconto').'</th>
+                <th width="10%" class="text-center">'.tr('Q.tà').'</th>
+                <th width="5%" class="text-center">#</th>
+            </tr>
+        </table>
+    </div>
+</div>
+
+<input type="hidden" name="permetti_movimenti_sotto_zero" id="permetti_movimenti_sotto_zero" value="'.setting('Permetti selezione articoli con quantità minore o uguale a zero in Documenti di Vendita').'">';
+
+echo '
+<script>
+var direzione = "'.$options['dir'].'";
+
+$(document).ready(function(){
+    init();
+
+    setTimeout(function(){
+        $("#barcode").focus();
+    }, 300);
+
+    $(".modal-body button").attr("disabled", true);
+});
+
+
+// gestione drop file
+$("#barcode_file").on("change", function (event) {
+    $("#articolo-missing").addClass("hidden");
+    $("#articolo-qta").addClass("hidden");
+
+    var barcodes = {};
+
+    let files = event.target.files;
+    //read csv file
+    let reader = new FileReader();
+    reader.readAsText(files[0]);
+    reader.onload = function (event) {
+        var csv = event.target.result;
+        var lines = csv.split("\n");
+        lines.forEach(function (line) {
+            if (line === "") {
+                return;
+            }
+            var qta = line.split(";")[1];
+            var barcode = line.split(";")[0];
+            barcode = barcode.replace(/\//g, "-");
+
+            //add barcode and qta in barcodes
+            if (barcodes[barcode] !== undefined) {
+                barcodes[barcode] += parseInt(qta);
+            } else {
+                barcodes[barcode] = parseInt(qta);
+            }
+        });
+
+        let permetti_movimenti_sotto_zero = $("#permetti_movimenti_sotto_zero").val();
+
+        $.getJSON(globals.rootdir + "/ajax_complete.php?op=articoli_barcode_file&barcodes=" + JSON.stringify(barcodes) + "&id_anagrafica='.$options['idanagrafica'].'", function(response) {
+            results = response["barcodeTrovati"];
+
+            $.each(results, function (i, barcode) {
+                dettaglio = barcode.dettaglio;
+                qta = barcode.qta;
+
+                let qta_input = $("#riga_barcode_" + dettaglio.id).find("[name^=qta]");
+                if (parseInt(dettaglio.qta) <= 0 && permetti_movimenti_sotto_zero == 0 && direzione === "entrata") {
+                    $("#articolo-qta").html("'.tr("Articolo ").'dettaglio.codice'.tr(" presente in quantità non sufficiente").'");
+                    $("#articolo-qta").removeClass("hidden");
+                    barcodeFileReset();
+                    return;
+                }
+
+                // Controllo se è già presente l\'articolo, in tal caso incremento la quantità, altrimenti inserisco la riga nuova
+                if (qta_input.length) {
+                    let nuova_qta = qta_input.val().toEnglish() + qta;
+
+                    if (dettaglio.qta < nuova_qta) {
+                        $("#articolo-qta").html("'.tr("Articolo ").'" + dettaglio.codice + "'.tr(" presente in quantità non sufficiente").'");
+                        $("#articolo-qta").removeClass("hidden");
+                        barcodeFileReset();
+                        return;
+                    }
+
+                    qta_input.val(nuova_qta).trigger("change");
+                } else {
+                    if (dettaglio.qta < qta) {
+                        $("#articolo-qta").html("'.tr("Articolo ").'" + dettaglio.codice + "'.tr(" presente in quantità non sufficiente").'");
+                        $("#articolo-qta").removeClass("hidden");
+                    } else {
+                        let prezzo_unitario = (direzione === "uscita") ? dettaglio.prezzo_acquisto : dettaglio.prezzo_vendita;
+                        prezzo_acquisto = parseFloat(dettaglio.prezzo_acquisto, 10).toLocale();
+                        prezzo_vendita = parseFloat(dettaglio.prezzo_vendita, 10).toLocale();
+
+                        let info_prezzi;
+                        if(direzione === "entrata") {
+                            info_prezzi = "Acquisto: " + (prezzo_acquisto) + " &euro;";
+                        }else{
+                            info_prezzi = "Vendita: " + (prezzo_vendita) + " &euro;";
+                        }
+
+                        $("#articoli_barcode").removeClass("hide");
+                        cleanup_inputs();
+
+                        var text = replaceAll($("#barcode-template").html(), "-id-", dettaglio.id);
+                        text = text.replace("|prezzo_unitario|", prezzo_unitario)
+                            .replace("|info_prezzi|", info_prezzi)
+                            .replace("|descrizione|", dettaglio.descrizione)
+                            .replace("|codice|", dettaglio.codice)
+                            .replace("|qta|", qta)
+                            .replace("|sconto_unitario|", 0)
+                            .replace("|tipo_sconto|", "")
+                            .replace("|id_dettaglio_fornitore|", dettaglio.id_dettaglio_fornitore ? dettaglio.id_dettaglio_fornitore : "")
+
+                        $("#articoli_barcode tbody").first().append(text);
+                        restart_inputs();
+
+                        $(".modal-body button").attr("disabled", false);
+
+                        // Gestione dinamica dei prezzi
+                        let tr = $("#riga_barcode_" + dettaglio.id);
+                        ottieniDettagliArticolo(dettaglio.id, tr).then(function() {
+                            if ($(tr).find("input[name^=prezzo_unitario]").val().toEnglish() === 0){
+                                aggiornaPrezzoArticolo(tr);
+                            } else {
+                                verificaPrezzoArticolo(tr);
+                            }
+
+                            var listino = getPrezzoListino(tr);
+
+                            if (listino) {
+                                $(tr).find("input[name^=prezzo_unitario]").val(listino).trigger("change");
+                            }
+
+                            if ($(tr).find("input[name^=sconto]").val().toEnglish() === 0){
+                                aggiornaScontoArticolo();
+                            } else {
+                                verificaScontoArticolo();
+                            }
+                        });
+                    }
+                }
+
+                barcodeFileReset();
+            });
+        });
+    };
+});
+
+// Gestione dell\'invio da tastiera
+$(document).keypress(function(event){
+    let key = window.event ? event.keyCode : event.which; // IE vs Netscape/Firefox/Opera
+    if (key == "13") {
+        event.preventDefault();
+        $("#barcode").blur()
+            .focus();
+    }
+});
+
+$("#barcode").off("keyup").on("keyup", function (event) {
+    $("#articolo-qta").html("'.tr("Articolo con quantità non sufficiente").'");
+
+    let key = window.event ? event.keyCode : event.which; // IE vs Netscape/Firefox/Opera
+    $("#articolo-missing").addClass("hidden");
+    $("#articolo-qta").addClass("hidden");
+
+    if (key !== 13) {
+        return;
+    }
+
+    $("#barcode").attr("disabled", true);
+    var barcode = $("#barcode").val();
+    if (!barcode){
+        barcodeReset();
+        return;
+    }
+
+    barcodeAdd(barcode, 1);
+});
+
+function barcodeAdd(barcode, qta) {
+    $.getJSON(globals.rootdir + "/ajax_select.php?op=articoli_barcode&search=" + barcode + "&id_anagrafica='.$options['idanagrafica'].'", function(response) {
+        let result = response.results[0];
+        if(!result){
+            $("#articolo-missing").removeClass("hidden");
+            barcodeReset();
+
+            return;
+        }
+
+        let qta_input = $("#riga_barcode_" + result.id).find("[name^=qta]");
+        let permetti_movimenti_sotto_zero = $("#permetti_movimenti_sotto_zero").val();
+        if (result.qta <= 0 && permetti_movimenti_sotto_zero == 0 && direzione === "entrata") {
+            $("#articolo-qta").removeClass("hidden");
+            barcodeReset();
+            return;
+        }
+
+        // Controllo se è già presente l\'articolo, in tal caso incremento la quantità, altrimenti inserisco la riga nuova
+        if (qta_input.length) {
+            let qta = qta_input.val().toEnglish();
+            let nuova_qta = qta + 1;
+
+            if (result.qta < nuova_qta) {
+                $("#articolo-qta").removeClass("hidden");
+                barcodeReset();
+                return;
+            }
+
+            qta_input.val(nuova_qta).trigger("change");
+        } else {
+            let prezzo_unitario = (direzione === "uscita") ? result.prezzo_acquisto : result.prezzo_vendita;
+            prezzo_acquisto = parseFloat(result.prezzo_acquisto, 10).toLocale();
+            prezzo_vendita = parseFloat(result.prezzo_vendita, 10).toLocale();
+
+            let info_prezzi;
+            if(direzione === "entrata") {
+                info_prezzi = "Acquisto: " + (prezzo_acquisto) + " &euro;";
+            }else{
+                info_prezzi = "Vendita: " + (prezzo_vendita) + " &euro;";
+            }
+
+            $("#articoli_barcode").removeClass("hide");
+            cleanup_inputs();
+
+            var text = replaceAll($("#barcode-template").html(), "-id-", result.id);
+            text = text.replace("|prezzo_unitario|", prezzo_unitario)
+                .replace("|info_prezzi|", info_prezzi)
+                .replace("|descrizione|", result.descrizione)
+                .replace("|codice|", result.codice)
+                .replace("|qta|", qta)
+                .replace("|sconto_unitario|", 0)
+                .replace("|tipo_sconto|", "")
+                .replace("|id_dettaglio_fornitore|", result.id_dettaglio_fornitore ? result.id_dettaglio_fornitore : "")
+
+            $("#articoli_barcode tbody").first().append(text);
+            restart_inputs();
+
+            $(".modal-body button").attr("disabled", false);
+
+            // Gestione dinamica dei prezzi
+            let tr = $("#riga_barcode_" + result.id);
+            ottieniDettagliArticolo(result.id, tr).then(function() {
+                if ($(tr).find("input[name^=prezzo_unitario]").val().toEnglish() === 0){
+                    aggiornaPrezzoArticolo(tr);
+                } else {
+                    verificaPrezzoArticolo(tr);
+                }
+
+                var listino = getPrezzoListino(tr);
+
+                if (listino) {
+                    $(tr).find("input[name^=prezzo_unitario]").val(listino).trigger("change");
+                }
+
+                if ($(tr).find("input[name^=sconto]").val().toEnglish() === 0){
+                    aggiornaScontoArticolo();
+                } else {
+                    verificaScontoArticolo();
+                }
+            });
+        }
+
+        barcodeReset();
+        $("#barcode").val("");
+    }, function(){
+        $("#articolo-missing").removeClass("hidden");
+        barcodeReset();
+    });
+}
+
+$(document).on("change", "input[name^=qta], input[name^=prezzo_unitario]", function() {
+    let tr = $(this).closest("tr");
+    verificaPrezzoArticolo(tr);
+});
+
+function barcodeReset() {
+    setTimeout(function(){
+        $("#barcode")
+            .attr("disabled",false)
+            .focus();
+    },200);
+}
+
+function barcodeFileReset() {
+    $("#barcode_file").val("");
+}
+
+function rimuoviRigaBarcode(id) {
+    if (confirm("'.tr('Eliminare questo articolo?').'")) {
+        $("#riga_barcode_" + id).remove();
+
+        //get rows number of #articoli_barcode
+        var num = $("#articoli_barcode tbody tr").length;
+
+        // Disabilito il pulsante di aggiunta se non ci sono articoli inseriti
+        if (num <= 1) {
+            $(".modal-body button").attr("disabled", true);
+            $("#articoli_barcode").addClass("hide");
+        }
+    }
+}
+
+/**
+* Restituisce il prezzo registrato per una specifica quantità dell\'articolo.
+*/
+function getDettaglioPerQuantita(qta, tr) {
+    const data = $(tr).data("dettagli");
+    if (!data) return null;
+
+    let dettaglio_predefinito = null;
+    let dettaglio_selezionato = null;
+    for (const dettaglio of data) {
+        if (dettaglio.minimo == null && dettaglio.massimo == null) {
+            dettaglio_predefinito = dettaglio;
+            continue;
+        }
+
+        if (qta >= dettaglio.minimo && qta <= dettaglio.massimo) {
+            dettaglio_selezionato = dettaglio;
+        }
+    }
+
+    if (dettaglio_selezionato == null) {
+        dettaglio_selezionato = dettaglio_predefinito;
+    }
+
+    return dettaglio_selezionato;
+}
+
+/**
+* Restituisce il prezzo registrato per una specifica quantità dell\'articolo.
+*/
+function getPrezzoPerQuantita(qta, tr) {
+    const dettaglio = getDettaglioPerQuantita(qta, tr);
+
+    return dettaglio ? parseFloat(dettaglio.prezzo_unitario) : 0;
+}
+
+/**
+* Restituisce lo sconto registrato per una specifica quantità dell\'articolo.
+*/
+function getScontoPerQuantita(qta, tr) {
+    const dettaglio = getDettaglioPerQuantita(qta, tr);
+
+    return dettaglio ? parseFloat(dettaglio.sconto_percentuale) : 0;
+}
+
+/**
+* Funzione per registrare localmente i dettagli definiti per l\'articolo in relazione ad una specifica anagrafica.
+*/
+function ottieniDettagliArticolo(id_articolo, tr) {
+    return $.get(globals.rootdir + "/ajax_complete.php?module=Articoli&op=dettagli_articolo&id_anagrafica='.$options['idanagrafica'].'&id_articolo=" + id_articolo + "&dir=" + direzione, function(response) {
+        const data = JSON.parse(response);
+
+        $(tr).data("dettagli", data);
+    });
+}
+
+/**
+* Funzione per verificare se il prezzo unitario corrisponde a quello registrato per l\'articolo, e proporre in automatico una correzione.
+*/
+function verificaPrezzoArticolo(tr) {
+    let qta = $(tr).find("input[name^=qta]").val().toEnglish();
+    let prezzo_previsto = getPrezzoPerQuantita(qta, tr);
+
+    let id = tr.attr("id");
+    let id_split = id.split("_");
+    let id_art = id_split[id_split.length - 1];
+
+    let prezzo_unitario_input = $(tr).find("#prezzo_unitario" + id_art);
+    let prezzo_unitario = prezzo_unitario_input.val().toEnglish();
+
+    let div = prezzo_unitario_input.closest(".input-group").parent().find("div[id*=errors]");
+
+    if (prezzo_previsto === prezzo_unitario || prezzo_previsto === 0) {
+        div.css("padding-top", "0");
+        div.html("");
+
+        return;
+    }
+
+    div.css("padding-top", "20px");
+    //div.html(`<small class="label label-info" >'.tr('Prezzo suggerito').': ` + prezzo_previsto.toLocale() + " " + globals.currency + `<button type="button" class="btn btn-xs btn-info pull-right" onclick="aggiornaPrezzoArticolo(this)"><i class="fa fa-refresh"></i> '.tr('Aggiorna').'</button></small>`);
+
+    //div.css("padding-top", "0");
+    div.html("");
+
+    let prezzo_anagrafica = prezzo_previsto;
+    let prezzo_listino = getPrezzoListino(tr);
+    let prezzo_std = getPrezzoScheda(tr);
+    let prezzo_last = getPrezzoUltimo(tr);
+    //let prezzo_minimo = 0; //parseFloat($("#idarticolo").selectData().minimo_vendita);
+    let prezzi_visibili = getPrezziListinoVisibili(tr);
+
+    if (prezzo_anagrafica || prezzo_listino || prezzo_std || prezzo_last || prezzi_visibili) {
+        div.html(`<table class="table table-extra-condensed table-prezzi` + id_art + `" style="background:#eee; margin-top:-13px;"><tbody>`);
+    }
+    let table = $(".table-prezzi" + id_art);
+
+    if (prezzo_anagrafica) {
+        table.append(`<tr><td class="pr_anagrafica"><small>'.($options['dir'] == 'uscita' ? tr('Prezzo listino') : tr('Netto cliente')).': '.Plugins::link(($options['dir'] == 'uscita' ? 'Listino Fornitori' : 'Netto Clienti'), $result['idarticolo'], tr('Visualizza'), null, '').'</small></td><td align="right" class="pr_anagrafica"><small>` + prezzo_anagrafica.toLocale() + ` ` + globals.currency + `</small></td>`);
+
+        let tr = table.find(".pr_anagrafica").parent();
+        if (prezzo_unitario == prezzo_anagrafica.toFixed(2)) {
+            tr.append(`<td><button type="button" class="btn btn-xs btn-info pull-right disabled" style="font-size:10px;"><i class="fa fa-check"></i> '.tr('Aggiorna').'</button></td>`);
+        } else{
+            tr.append(`<td><button type="button" class="btn btn-xs btn-info pull-right" onclick="aggiornaPrezzoArticolo(this)" style="font-size:10px;"><i class="fa fa-refresh"></i> '.tr('Aggiorna').'</button></td>`);
+        }
+        table.append(`</tr>`);
+    }
+
+    if (prezzo_listino) {
+        table.append(`<tr><td class="pr_listino"><small>'.tr('Prezzo listino').': '.Modules::link('Listini Cliente', $id_listino, tr('Visualizza'), null, '').'</small></td><td align="right" class="pr_listino"><small>` + prezzo_listino.toLocale() + ` ` + globals.currency + `</small></td>`);
+
+        let tr = table.find(".pr_listino").parent();
+        if (prezzo_unitario == prezzo_listino.toFixed(2)) {
+            tr.append(`<td><button type="button" class="btn btn-xs btn-info pull-right disabled" style="font-size:10px;"><i class="fa fa-check"></i> '.tr('Aggiorna').'</button></td>`);
+        } else{
+            tr.append(`<td><button type="button" class="btn btn-xs btn-info pull-right" onclick="aggiornaPrezzoArticolo(this)" style="font-size:10px;"><i class="fa fa-refresh"></i> '.tr('Aggiorna').'</button></td>`);
+        }
+        table.append(`</tr>`);
+    }
+
+    if (prezzo_std) {
+        table.append(`<tr><td class="pr_std"><small>'.tr('Prezzo articolo').': '.Modules::link('Articoli', $result['idarticolo'], tr('Visualizza'), null, '').'</small></td><td align="right" class="pr_std"><small>` + prezzo_std.toLocale() + ` ` + globals.currency + `</small></td></tr>`);
+
+        let tr = table.find(".pr_std").parent();
+        if (prezzo_unitario == prezzo_std.toFixed(2)) {
+            tr.append(`<td><button type="button" class="btn btn-xs btn-info pull-right disabled" style="font-size:10px;"><i class="fa fa-check"></i> '.tr('Aggiorna').'</button></td>`);
+        } else{
+            tr.append(`<td><button type="button" class="btn btn-xs btn-info pull-right" onclick="aggiornaPrezzoArticolo(this)" style="font-size:10px;"><i class="fa fa-refresh"></i> '.tr('Aggiorna').'</button></td>`);
+        }
+        table.append(`</tr>`);
+    }
+
+    if (prezzo_last) {
+        table.append(`<tr><td class="pr_last"><small>'.tr('Ultimo prezzo').': '.Modules::link('Articoli', $result['idarticolo'], tr('Visualizza'), null, '').'</small></td><td align="right" class="pr_last"><small>` + prezzo_last.toLocale() + ` ` + globals.currency + `</small></td></tr>`);
+
+        let tr = table.find(".pr_last").parent();
+        if (prezzo_unitario == prezzo_last.toFixed(2)) {
+            tr.append(`<td><button type="button" class="btn btn-xs btn-info pull-right disabled" style="font-size:10px;"><i class="fa fa-check"></i> '.tr('Aggiorna').'</button></td>`);
+        } else{
+            tr.append(`<td><button type="button" class="btn btn-xs btn-info pull-right" onclick="aggiornaPrezzoArticolo(this)" style="font-size:10px;"><i class="fa fa-refresh"></i> '.tr('Aggiorna').'</button></td>`);
+        }
+        table.append(`</tr>`);
+    }
+
+    /*if (prezzo_minimo) {
+        table.append(`<tr><td class="pr_minimo"><small>'.tr('Prezzo minimo').': '.Modules::link('Articoli', $result['idarticolo'], tr('Visualizza'), null, '').'</small></td><td align="right" class="pr_minimo"><small>` + prezzo_minimo.toLocale() + ` ` + globals.currency + `</small></td></tr>`);
+
+        let tr = table.find(".pr_minimo").parent();
+        if (prezzo_unitario == prezzo_minimo.toFixed(2)) {
+            tr.append(`<td><button type="button" class="btn btn-xs btn-info pull-right disabled" style="font-size:10px;"><i class="fa fa-check"></i> '.tr('Aggiorna').'</button></td>`);
+        } else{
+            tr.append(`<td><button type="button" class="btn btn-xs btn-info pull-right" onclick="aggiornaPrezzoArticolo(this)" style="font-size:10px;"><i class="fa fa-refresh"></i> '.tr('Aggiorna').'</button></td>`);
+        }
+        table.append(`</tr>`);
+    }*/
+
+    if (prezzi_visibili) {
+        let i = 0;
+        for (const prezzo_visibile of prezzi_visibili) {
+            i++;
+            let prezzo_listino_visibile = parseFloat(prezzo_visibile.prezzo_unitario_listino_visibile);
+            table.append(`<tr><td class="pr_visibile_`+ i +`"><small>'.tr('Listino visibile ').'(` + prezzo_visibile.nome + `): </small></td><td align="right" class="pr_visibile_`+ i +`"><small>` + prezzo_listino_visibile.toLocale() + ` ` + globals.currency + `</small></td></tr>`);
+
+            let tr = table.find(".pr_visibile_"+ i).parent();
+            if (prezzo_unitario == prezzo_listino_visibile.toFixed(2)) {
+                tr.append(`<td><button type="button" class="btn btn-xs btn-info pull-right disabled" style="font-size:10px;"><i class="fa fa-check"></i> '.tr('Aggiorna').'</button></td>`);
+            } else{
+                tr.append(`<td><button type="button" class="btn btn-xs btn-info pull-right" onclick="aggiornaPrezzoArticolo(this)" style="font-size:10px;"><i class="fa fa-refresh"></i> '.tr('Aggiorna').'</button></td>`);
+            }
+            table.append(`</tr>`);
+        }
+    }
+
+    if (prezzo_anagrafica || prezzo_listino || prezzo_std || prezzo_last || prezzi_visibili) {
+        table.append(`</tbody></table>`);
+    }
+}
+
+/**
+* Restituisce il prezzo del listino registrato per l\'articolo-anagrafica.
+*/
+function getPrezzoListino(tr) {
+    const data = $(tr).data("dettagli");
+    if (!data) return null;
+
+    let dettaglio_listino = null;
+    for (const dettaglio of data) {
+        if (dettaglio.prezzo_unitario_listino != null) {
+            dettaglio_listino = dettaglio;
+            continue;
+        }
+    }
+
+    return dettaglio_listino ? parseFloat(dettaglio_listino.prezzo_unitario_listino) : 0;
+}
+
+/**
+* Restituisce il prezzo della scheda articolo.
+*/
+function getPrezzoScheda(tr) {
+    const data = $(tr).data("dettagli");
+    if (!data) return null;
+
+    let dettaglio_scheda = null;
+    for (const dettaglio of data) {
+        if (dettaglio.prezzo_scheda != null) {
+            dettaglio_scheda = dettaglio;
+            continue;
+        }
+    }
+
+    return dettaglio_scheda ? parseFloat(dettaglio_scheda.prezzo_scheda) : 0;
+}
+
+/**
+* Restituisce l\'ultimo prezzo registrato dell\' articolo.
+*/
+function getPrezzoUltimo(tr) {
+    const data = $(tr).data("dettagli");
+    if (!data) return null;
+
+    let dettaglio_ultimo = null;
+    for (const dettaglio of data) {
+        if (dettaglio.prezzo_ultimo != null) {
+            dettaglio_ultimo = dettaglio;
+            continue;
+        }
+    }
+
+    return dettaglio_ultimo ? parseFloat(dettaglio_ultimo.prezzo_ultimo) : 0;
+}
+
+/**
+* Restituisce i prezzi dei listini sempre visibili registrati per l\'articolo.
+*/
+function getPrezziListinoVisibili(tr, nome = "") {
+    const data = $(tr).data("dettagli");
+    if (!data) return null;
+
+    let dettaglio_prezzi_visibili = [];
+    for (const dettaglio of data) {
+        if (dettaglio.prezzo_unitario_listino_visibile != null) {
+            if (nome != "") {
+                if (dettaglio.nome == nome) {
+                    dettaglio_prezzi_visibili = parseFloat(dettaglio.prezzo_unitario_listino_visibile);
+                    continue;
+                }
+            } else {
+                dettaglio_prezzi_visibili.push(dettaglio);
+            }
+        }
+    }
+
+    return dettaglio_prezzi_visibili;
+}
+
+/**
+* Funzione per aggiornare il prezzo unitario sulla base dei valori automatici.
+*/
+function aggiornaPrezzoArticolo(button) {
+    let fist_tr = $(button).closest("tr");
+    let tr = $(button).closest("table").closest("tr");
+
+    let prezzo_previsto = fist_tr.find("td:eq(1)").text();
+    split_prezzo_previsto = prezzo_previsto.split(" ");
+    prezzo_previsto = split_prezzo_previsto[0];
+
+    //get tr id
+    let id = tr.attr("id");
+    let id_split = id.split("_");
+    let id_art = id_split[id_split.length - 1];
+
+    tr.find("#prezzo_unitario" + id_art).val(prezzo_previsto).trigger("change");
+
+    // Aggiornamento automatico di guadagno e margine
+    if (direzione === "entrata") {
+        //aggiorna_guadagno();
+    }
+}
+
+/**
+* Funzione per verificare se lo sconto unitario corrisponde a quello registrato per l\'articolo, e proporre in automatico una correzione.
+*/
+function verificaScontoArticolo(tr) {
+    let qta = $(tr).find("input[name^=qta]").val().toEnglish();
+    let sconto_previsto = getScontoPerQuantita(qta, tr);
+
+    let sconto_input = $(tr).find("input[name^=sconto]");
+    let sconto = sconto_input.val().toEnglish();
+
+    let div = sconto_input.parent().next();
+    if (sconto_previsto === 0 || sconto_previsto === sconto || $(tr).find("input[name^=tipo_sconto]").val() === "UNT") {
+        div.css("padding-top", "0");
+        div.html("");
+
+        return;
+    }
+
+    div.css("padding-top", "5px");
+    div.html(`<small class="label label-info" >'.tr('Sconto suggerito').': ` + sconto_previsto.toLocale()  + `%<button type="button" class="btn btn-xs btn-info pull-right" onclick="aggiornaScontoArticolo(this)"><i class="fa fa-refresh"></i> '.tr('Aggiorna').'</button></small>`);
+}
+
+/**
+* Funzione per aggiornare lo sconto unitario sulla base dei valori automatici.
+*/
+function aggiornaScontoArticolo(button) {
+    let tr = $(button).closest("tr");
+    let qta = tr.find("input[name^=qta]").val(); //.toEnglish();
+    let sconto_previsto = getScontoPerQuantita(qta, tr);
+
+    $("#sconto").val(sconto_previsto).trigger("change");
+
+    // Aggiornamento automatico di guadagno e margine
+    if (direzione === "entrata") {
+        //aggiorna_guadagno();
+    }
+}
+</script>
+
+<table class="hidden">
+    <tbody id="barcode-template">
+        <tr id="riga_barcode_-id-">
+            <td>
+                |codice| - |descrizione|
+                <br><small>|info_prezzi|</small>
+                <input type="hidden" name="id_dettaglio_fornitore[-id-]" value="|id_dettaglio_fornitore|">
+            </td>
+            <td>
+                {[ "type": "number", "name": "prezzo_unitario[-id-]", "value": "|prezzo_unitario|", "required": 0, "icon-after": "'.currency().'" ]}
+            </td>
+
+            <td>
+                {[ "type": "number", "name": "sconto[-id-]", "value": "|sconto_unitario|", "icon-after": "choice|untprc||tipo_sconto|", "help": "'.tr('Il valore positivo indica uno sconto. Per applicare una maggiorazione inserire un valore negativo.').'" ]}
+            </td>
+
+            <td>
+                {[ "type": "number", "name": "qta[-id-]", "required": 0, "value": "|qta|", "decimals": "qta" ]}
+            </td>
+
+            <td width="5%" class="text-center">
+                <button type="button" class="btn btn-xs btn-danger" onclick="rimuoviRigaBarcode(\'-id-\')">
+                    <i class="fa fa-trash"></i>
+                </button>
+            </td>
+        </tr>
+    </tbody>
+</table>';

--- a/include/common/importa.php
+++ b/include/common/importa.php
@@ -70,6 +70,10 @@ echo '
     <input type="hidden" name="class" value="'.get_class($documento).'">
     <input type="hidden" name="is_evasione" value="1">';
 
+    if ($options['type'] == 'ordine') {
+        echo '<input type="hidden" name="id_sede_partenza" value="'.$options['documento']['id_sede_partenza'].'">';
+    }
+
 // Creazione fattura dal documento
 if (!empty($options['create_document'])) {
     echo '
@@ -115,7 +119,7 @@ if (!empty($options['create_document'])) {
             <div class="col-md-6">
                 {[ "type": "select", "label": "'.tr('Tipo documento').'", "name": "idtipodocumento", "required": 1, "values": "query=SELECT id, CONCAT(codice_tipo_documento_fe, \' - \', descrizione) AS descrizione FROM co_tipidocumento WHERE enabled = 1 AND dir = '.prepare($dir).' ORDER BY codice_tipo_documento_fe", "value": "'.$idtipodocumento.'" ]}
             </div>
-            
+
             <div class="col-md-6">
                 {[ "type": "select", "label": "'.tr('Ritenuta previdenziale').'", "name": "id_ritenuta_contributi", "value": "$id_ritenuta_contributi$", "values": "query=SELECT * FROM co_ritenuta_contributi" ]}
             </div>';
@@ -175,6 +179,13 @@ if (!empty($options['create_document'])) {
         echo '
             <div class="col-md-6">
                 {[ "type": "select", "label": "'.$tipo_anagrafica.'", "name": "idanagrafica", "required": 1, "ajax-source": "'.$ajax.'", "icon-after": "add|'.Modules::get('Anagrafiche')['id'].'|tipoanagrafica='.$tipo_anagrafica.'" ]}
+            </div>';
+    }
+
+    if ($options['type'] == 'preventivo' && ($options['op'] == 'add_ordine_cliente' || $options['op'] == 'add_ordine_fornitore' || $options['op'] == 'add_preventivo')) {
+        echo '
+            <div class="col-md-6">
+			    {[ "type": "select", "label": "'.tr('Sede di partenza').'", "name": "id_sede_partenza", "required": 1, "ajax-source": "sedi-partenza", "select-options": '.json_encode(['id_module' => $id_module, 'is_sezionale' => 1]).', "value": "0" ]}
             </div>';
     }
 
@@ -656,7 +667,7 @@ echo '
         ricalcolaTotale();
     });
 
-    $("#import_all").click(function(){    
+    $("#import_all").click(function(){
         if( $(this).is(":checked") ){
             $(".check").each(function(){
                 if( !$(this).is(":checked") ){

--- a/include/common/riga.php
+++ b/include/common/riga.php
@@ -67,27 +67,24 @@ if ($options['dir'] == 'entrata') {
             var prezzi_ivati = input("prezzi_ivati").get();
             var costo_unitario = $("#costo_unitario").val().toEnglish();
             var prezzo = 0;
-            var sconto = $("#sconto").val().toEnglish();
-
-            if ($("#modals select[id^=\'tipo_sconto\']").val() === "PRC") {
-                sconto = sconto / 100 * $("#prezzo_unitario").val().toEnglish();
-            }
             if (prezzi_ivati!=0) {
                 percentuale_iva = input("idiva").getElement().selectData().percentuale;
-                prezzo = ($("#prezzo_unitario").val().toEnglish() / (1 + percentuale_iva / 100)) - (sconto / (1 + percentuale_iva / 100));
+                prezzo = $("#prezzo_unitario").val().toEnglish() / (1 + percentuale_iva / 100);
             } else {
-                prezzo = $("#prezzo_unitario").val().toEnglish() - sconto;
+                prezzo = $("#prezzo_unitario").val().toEnglish();
             }
-            
+            var sconto = $("#sconto").val().toEnglish();
+            if ($("#modals select[id^=\'tipo_sconto\']").val() === "PRC") {
+                sconto = sconto / 100 * prezzo;
+            }
             var provvigione = $("#provvigione").val().toEnglish();
             if ($("#modals select[id^=\'tipo_provvigione\']").val() === "PRC") {
-                provvigione = provvigione / 100 * prezzo;
+                provvigione = provvigione / 100 * (prezzo - sconto);
             }
 
-            var guadagno = prezzo - provvigione - costo_unitario;
-            var ricarico = ((prezzo / costo_unitario) - 1) * 100;
-            var margine = (1 - (costo_unitario / prezzo)) * 100;            
-            var parent = $("#costo_unitario").closest("div").parent();
+            var guadagno = prezzo - sconto - provvigione - costo_unitario;
+            var ricarico = (((prezzo - sconto) / costo_unitario) - 1) * 100;
+            var margine = (1 - (costo_unitario / (prezzo - sconto))) * 100;            var parent = $("#costo_unitario").closest("div").parent();
             var div = $(".margine");
             var mediaponderata = 0;
 
@@ -144,7 +141,7 @@ if ($options['dir'] == 'entrata') {
                             </td>\
                         </tr>\
                     </table>");
-                    
+
             if (guadagno < 0) {
                 parent.addClass("has-error");
                 $(".table-margine").addClass("label-danger").removeClass("label-success");
@@ -185,7 +182,7 @@ if ($options['dir'] == 'entrata') {
     <div class="row">
         <div class="col-md-4 margine"></div>
         <div class="col-md-4 prezzi"></div>';
-        
+
         // Provvigione
         echo '
         <div class="col-md-4">
@@ -348,3 +345,38 @@ if (in_array($module['name'], ['Fatture di vendita', 'Fatture di acquisto'])) {
         }
     </script>';
 }
+
+if (in_array($module['name'], ['Ordini fornitore'])) {
+    echo '
+    <div class="box box-info collapsable collapsed-box">
+        <div class="box-header with-border">
+            <h3 class="box-title">'.tr('Dati di vendita').'</h3>
+            <div class="box-tools pull-right">
+                <button type="button" class="btn btn-box-tool" data-widget="collapse"><i class="fa fa-plus"></i></button>
+            </div>
+        </div>
+
+        <div class="box-body">
+            <div class="row">
+                <div class="col-md-12">
+                    <table id="tbl_vendite" class="table table-striped table-condensed table-bordered">
+                        <thead>
+                            <tr>
+                                <th>'.tr('Mese').'</th>
+                                <th>'.tr('Q.tà').'</th>
+                                <th width="20%" class="text-center">'.tr('Totale').'</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <td colspan="3" class="text-center">' . tr('Nessuna Vendita') . '</td>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+    </script>';
+}
+

--- a/migration.sql
+++ b/migration.sql
@@ -1,0 +1,14 @@
+CREATE TABLE `mg_articoli_sedi` (
+    `id` int(11) NOT NULL AUTO_INCREMENT,
+    `id_articolo` int(11) NOT NULL,
+    `id_sede` int(11) DEFAULT NULL,
+    `threshold_qta` int(11) NOT NULL COMMENT 'soglia minima',
+    `created_at` timestamp NOT NULL DEFAULT current_timestamp(),
+    `updated_at` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+INSERT INTO `zz_settings` (`nome`, `valore`, `tipo`, `editable`, `sezione`, `created_at`, `updated_at`, `order`, `help`)
+SELECT 'Gestisci soglia minima per magazzino', '1', 'boolean', '1', 'Magazzino', '2022-12-21 14:51:03', '2023-01-05 11:29:48', NULL, NULL
+FROM `zz_settings`
+WHERE ((`id` = '21'));

--- a/modules/articoli/edit.php
+++ b/modules/articoli/edit.php
@@ -166,16 +166,46 @@ use Modules\Iva\Aliquota;
 
                 <div class="panel-body">
                     <div class="row">
-                        <div class="col-md-4">
+                        <div class="col-md-6">
                             {[ "type": "number", "label": "<?php echo tr('Prezzo di acquisto'); ?>", "name": "prezzo_acquisto", "value": "$prezzo_acquisto$", "icon-after": "<?php echo currency(); ?>", "help": "<?php echo tr('Prezzo di acquisto previsto per i fornitori i cui dati non sono stati inseriti nel plugin Fornitori'); ?>." ]}
                         </div>
 
-                        <div class="col-md-4">
+                        <div class="col-md-6">
                             {[ "type": "number", "label": "<?php echo tr('Coefficiente di vendita'); ?>", "name": "coefficiente", "value": "$coefficiente$", "help": "<?php echo tr('Imposta un coefficiente per calcolare automaticamente il prezzo di vendita quando cambia il prezzo di acquisto'); ?>." ]}
                         </div>
 
-                        <div class="col-md-4">
+                        <!--<div class="col-md-4">
                             {[ "type": "number", "label": "<?php echo tr('Soglia minima quantità'); ?>", "name": "threshold_qta", "value": "$threshold_qta$", "decimals": "qta", "min-value": "undefined" ]}
+                        </div>-->
+                    </div>
+
+                    <div class="row">
+                        <div class="col-md-12">
+                            <label for="tbl_soglia_minima"><?php echo tr('Soglia minima per sede') ?></label>
+                            <table id="tbl_soglia_minima" class="table table-striped table-condensed table-bordered">
+                                <thead>
+                                    <tr>
+                                        <th><?php echo tr('Sede') ?></th>
+                                        <th width="20%" class="text-center"><?php echo tr('Soglia minima') ?></th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <td><?php echo $articoloSedeLegale['nomesede'] ?></td>
+                                        <td>
+                                            {[ "type": "number", "name": "threshold_qta_sedi[<?php echo $articoloSedeLegale['id_sede'] ?>]", "value": "<?php echo $articoloSedeLegale['threshold_qta'] ?? 0 ?>", "decimals": "qta", "min-value": "0" ]}
+                                        </td>
+                                    </tr>
+                                    <?php foreach ($articoloSedi as $articoloSede) { ?>
+                                    <tr>
+                                        <td><?php echo $articoloSede['nomesede'] ?></td>
+                                        <td>
+                                            {[ "type": "number", "name": "threshold_qta_sedi[<?php echo $articoloSede['id_sede'] ?>]", "value": "<?php echo $articoloSede['threshold_qta'] ?? 0 ?>", "decimals": "qta", "min-value": "0" ]}
+                                        </td>
+                                    </tr>
+                                    <?php } ?>
+                                </tbody>
+                            </table>
                         </div>
                     </div>
 

--- a/modules/articoli/init.php
+++ b/modules/articoli/init.php
@@ -25,5 +25,35 @@ if (isset($id_record)) {
     $articolo = Articolo::withTrashed()->find($id_record);
     $articolo->nome_variante;
 
+    $gestisciMagazzini = $dbo->fetchOne('SELECT * FROM zz_settings WHERE nome = "Gestisci soglia minima per magazzino"');
+
+    if ($gestisciMagazzini['valore'] == '1') {
+        $articoloSedeLegale = $dbo->fetchOne(
+            'SELECT "0" as id_sede , CONCAT("Sede legale - ", citta) as nomesede, mgas.id_articolo, mgas.threshold_qta
+            FROM an_anagrafiche ana
+            LEFT JOIN mg_articoli_sedi mgas
+            ON mgas.id_sede = " "  AND mgas.id_articolo = ' . prepare($id_record) . '
+            WHERE ana.idanagrafica = 1'
+        );
+
+        $articoloSedi = $dbo->fetchArray(
+            'SELECT ans.id as id_sede, ans.nomesede, mgas.id_articolo, mgas.threshold_qta
+            FROM an_sedi ans
+            LEFT JOIN mg_articoli_sedi mgas
+            ON ans.id = mgas.id_sede AND mgas.id_articolo = ' . prepare($id_record) . '
+            WHERE ans.idanagrafica = 1'
+        );
+    } else {
+        $articoloSedeLegale = $dbo->fetchOne(
+            'SELECT "0" as id_sede , CONCAT("Sede legale - ", citta) as nomesede, mga.id as id_articolo, mga.threshold_qta
+            FROM an_anagrafiche ana
+            LEFT JOIN mg_articoli mga
+            ON ana.idanagrafica = 1
+            WHERE mga.id = ' . prepare($id_record) . ''
+        );
+
+        $articoloSedi = [];
+    }
+
     $record = $dbo->fetchOne('SELECT *, (SELECT COUNT(id) FROM mg_prodotti WHERE id_articolo = mg_articoli.id) AS serial FROM mg_articoli WHERE id='.prepare($id_record));
 }

--- a/modules/articoli/plugins/articoli.giacenze.php
+++ b/modules/articoli/plugins/articoli.giacenze.php
@@ -21,25 +21,59 @@ include_once __DIR__.'/../../../core.php';
 
 $impegnato = 0;
 $ordinato = 0;
+$gestisciMagazzini = $dbo->fetchOne('SELECT * FROM zz_settings WHERE nome = "Gestisci soglia minima per magazzino"');
+$sedi = $dbo->fetchArray('(SELECT "0" AS id, IF(indirizzo!=\'\', CONCAT_WS(" - ", "'.tr('Sede legale').'", CONCAT(citta, \' (\', indirizzo, \')\')), CONCAT_WS(" - ", "'.tr('Sede legale').'", citta)) AS nomesede FROM an_anagrafiche WHERE idanagrafica = '.prepare(setting('Azienda predefinita')).') UNION (SELECT id, IF(indirizzo!=\'\',CONCAT_WS(" - ", nomesede, CONCAT(citta, \' (\', indirizzo, \')\')), CONCAT_WS(" - ", nomesede, citta )) AS nomesede FROM an_sedi WHERE idanagrafica='.prepare(setting('Azienda predefinita')).')');
+$giacenze = $articolo->getGiacenze();
 
-$query = 'SELECT
-    or_ordini.id AS id,
-    or_ordini.numero,
-    or_ordini.numero_esterno,
-    data,
-    SUM(or_righe_ordini.qta) AS qta_ordinata,
-    SUM(or_righe_ordini.qta - or_righe_ordini.qta_evasa) AS qta_impegnata,
-    or_righe_ordini.um
-FROM or_ordini
-    INNER JOIN or_righe_ordini ON or_ordini.id = or_righe_ordini.idordine
-    INNER JOIN or_statiordine ON or_ordini.idstatoordine=or_statiordine.id
-WHERE idarticolo = '.prepare($articolo->id)."
-     AND (SELECT dir FROM or_tipiordine WHERE or_tipiordine.id=or_ordini.idtipoordine) = '|dir|'
-     AND (or_righe_ordini.qta - or_righe_ordini.qta_evasa) > 0
-     AND or_righe_ordini.confermato = 1
-     AND or_statiordine.impegnato = 1
-GROUP BY or_ordini.id
-HAVING qta_ordinata > 0";
+if ($gestisciMagazzini['valore'] == '1') {
+    $query = 'SELECT
+        or_ordini.id_sede_partenza,
+        or_ordini.id AS id,
+        or_ordini.numero,
+        or_ordini.numero_esterno,
+        data,
+        SUM(or_righe_ordini.qta) AS qta_ordinata,
+        SUM(or_righe_ordini.qta - or_righe_ordini.qta_evasa) AS qta_impegnata,
+        or_righe_ordini.um,
+        IF(
+            or_ordini.id_sede_partenza = 0,
+            CONCAT_WS(" - ", "Sede legale", CONCAT(citta, " (", indirizzo, ")")),
+            (
+                SELECT CONCAT_WS(" - ", nomesede, CONCAT(citta, " (", indirizzo, ")"))
+                FROM an_sedi WHERE idanagrafica="1" AND or_ordini.id_sede_partenza = an_sedi.id
+            )
+        ) AS Magazzino
+        FROM or_ordini
+        INNER JOIN or_righe_ordini ON or_ordini.id = or_righe_ordini.idordine
+        INNER JOIN an_anagrafiche ON an_anagrafiche.idanagrafica = 1
+        INNER JOIN or_statiordine ON or_ordini.idstatoordine=or_statiordine.id
+        WHERE idarticolo = '.prepare($articolo->id).'
+        AND (SELECT dir FROM or_tipiordine WHERE or_tipiordine.id=or_ordini.idtipoordine) = "|dir|"
+        AND (or_righe_ordini.qta - or_righe_ordini.qta_evasa) > 0
+        AND or_righe_ordini.confermato = 1
+        AND or_statiordine.impegnato = 1
+        GROUP BY or_ordini.id
+        HAVING qta_ordinata > 0';
+} else {
+    $query = 'SELECT
+        or_ordini.id AS id,
+        or_ordini.numero,
+        or_ordini.numero_esterno,
+        data,
+        SUM(or_righe_ordini.qta) AS qta_ordinata,
+        SUM(or_righe_ordini.qta - or_righe_ordini.qta_evasa) AS qta_impegnata,
+        or_righe_ordini.um
+        FROM or_ordini
+        INNER JOIN or_righe_ordini ON or_ordini.id = or_righe_ordini.idordine
+        INNER JOIN or_statiordine ON or_ordini.idstatoordine=or_statiordine.id
+        WHERE idarticolo = '.prepare($articolo->id).'
+        AND (SELECT dir FROM or_tipiordine WHERE or_tipiordine.id=or_ordini.idtipoordine) = "|dir|"
+        AND (or_righe_ordini.qta - or_righe_ordini.qta_evasa) > 0
+        AND or_righe_ordini.confermato = 1
+        AND or_statiordine.impegnato = 1
+        GROUP BY or_ordini.id
+        HAVING qta_ordinata > 0';
+}
 
 echo '
 <div class="panel panel-primary">
@@ -60,9 +94,18 @@ echo '
     </div>
 </div>';
 
-/*
- ** Impegnato
+/**
+ * Impegnato
  */
+
+if ($gestisciMagazzini['valore'] == '1') {
+    $impegnatoPerSede = [];
+
+    foreach ($sedi as $sede) {
+        $impegnatoPerSede[$sede['id']] = 0;
+    }
+}
+
 echo '
 <div class="row">
 	<div class="col-md-3">
@@ -72,66 +115,91 @@ echo '
                 <i class="fa fa-question-circle-o"></i></span></h3>
 			</div>
 			<div class="panel-body" style="min-height:98px;">';
+                $ordini = $dbo->fetchArray(str_replace('|dir|', 'entrata', $query));
+                $impegnato = sum(array_column($ordini, 'qta_impegnata'));
+                if (!empty($ordini)) {
+                    echo '
+                    <table class="table table-bordered table-condensed table-striped">
+                        <thead>
+                            <tr>';
+                                if ($gestisciMagazzini['valore'] == '1') {
+                                    echo
+                                    '<th>'.tr('Magazzino').'</th>';
+                                }
+                                echo
+                                '<th>'.tr('Descrizione').'</th>
+                                <th class="text-right" style="min-width:40px">'.$record['um'].'</th>
+                            </tr>
+                        </thead>
+                        <tbody>';
+                        $modulo = Modules::get('Ordini cliente');
+                        foreach ($ordini as $documento) {
+                            $numero = !empty($documento['numero_esterno']) ? $documento['numero_esterno'] : $documento['numero'];
+                            $qta = $documento['qta_impegnata'];
+                            echo '
+                            <tr>';
+                                if ($gestisciMagazzini['valore'] == '1') {
+                                    $impegnatoPerSede[$documento['id_sede_partenza']] += $qta;
 
-$ordini = $dbo->fetchArray(str_replace('|dir|', 'entrata', $query));
-$impegnato = sum(array_column($ordini, 'qta_impegnata'));
-if (!empty($ordini)) {
-    echo '
-                <table class="table table-bordered table-condensed table-striped">
-                    <thead>
-                        <tr>
-                            <th>'.tr('Descrizione').'</th>
-                            <th class="text-right">'.$record['um'].'</th>
+                                    echo
+                                    '<td>
+                                        <small>
+                                            '.$documento['Magazzino'].'
+                                        </small>
+                                    </td>';
+                                }
+
+                                echo
+                                '<td>
+                                    <small>
+                                        '.Modules::link($modulo['id'], $documento['id'], tr('Ordine num. _NUM_ del _DATE_', [
+                                            '_NUM_' => $numero,
+                                            '_DATE_' => dateFormat($documento['data']),
+                                        ])).'
+                                    </small>
+                                </td>
+                                <td class="text-right">
+                                    <small>'.numberFormat($qta, 2).'</small>
+                                </td>
+                            </tr>';
+                        }
+                        echo '
+                        <tr>';
+                            if ($gestisciMagazzini['valore'] == '1') {
+                                echo
+                                '<td></td>';
+                            }
+                            echo
+                            '<td class="text-right">
+                                <small><b>'.tr('Totale').'</b></small>
+                            </td>
+                            <td class="text-right">
+                                <small>'.numberFormat($impegnato, 2).'</small>
+                            </td>
                         </tr>
-                    </thead>
-
-                    <tbody>';
-
-    $modulo = Modules::get('Ordini cliente');
-    foreach ($ordini as $documento) {
-        $numero = !empty($documento['numero_esterno']) ? $documento['numero_esterno'] : $documento['numero'];
-        $qta = $documento['qta_impegnata'];
-
-        echo '
-                    <tr>
-                        <td>
-                            <small>
-                                '.Modules::link($modulo['id'], $documento['id'], tr('Ordine num. _NUM_ del _DATE_', [
-                    '_NUM_' => $numero,
-                    '_DATE_' => dateFormat($documento['data']),
-                ])).'
-                            </small>
-                        </td>
-                        <td class="text-right">
-                            <small>'.numberFormat($qta).'</small>
-                        </td>
-                    </tr>';
-    }
-
-    echo '
-                    <tr>
-                        <td class="text-right">
-                            <small><b>'.tr('Totale').'</b></small>
-                        </td>
-                        <td class="text-right">
-                            <small>'.numberFormat($impegnato).'</small>
-                        </td>
-                    </tr>
-
-                </table>';
-} else {
-    echo '
-                <p>'.tr('Nessun ordine cliente con quantità da evadere individuato').'.</p>';
-}
-echo '
+                    </table>';
+                } else {
+                    echo '
+                    <p>'.tr('Nessun ordine cliente con quantità da evadere individuato').'.</p>';
+                }
+            echo '
 			</div>
 		</div>
 	</div>';
 
-/*
- ** In ordine
- */
-echo '
+    /**
+    * In ordine
+    */
+
+    if ($gestisciMagazzini['valore'] == '1') {
+        $ordinatoPerSede = [];
+
+        foreach ($sedi as $sede) {
+            $ordinatoPerSede[$sede['id']] = 0;
+        }
+    }
+
+    echo '
 	<div class="col-md-3">
 		<div class="panel panel-primary">
 			<div class="panel-heading">
@@ -140,113 +208,218 @@ echo '
 			</div>
 			<div class="panel-body" style="min-height:98px;">';
 
-$ordini = $dbo->fetchArray(str_replace('|dir|', 'uscita', $query));
-$ordinato = sum(array_column($ordini, 'qta_ordinata'));
-if (!empty($ordini)) {
-    echo '
+            $ordini = $dbo->fetchArray(str_replace('|dir|', 'uscita', $query));
+            $ordinato = sum(array_column($ordini, 'qta_ordinata'));
+            if (!empty($ordini)) {
+                echo '
                 <table class="table table-bordered table-condensed table-striped">
                     <thead>
-                        <tr>
-                            <th>'.tr('Descrizione').'</th>
-                            <th class="text-right">'.$record['um'].'</th>
+                        <tr>';
+                            if ($gestisciMagazzini['valore'] == '1') {
+                                echo
+                                '<th>'.tr('Magazzino').'</th>';
+                            }
+                            echo
+                            '<th>'.tr('Descrizione').'</th>
+                            <th class="text-right" style="min-width:40px">'.$record['um'].'</th>
                         </tr>
                     </thead>
 
                     <tbody>';
+                        $modulo = Modules::get('Ordini fornitore');
+                        foreach ($ordini as $documento) {
+                            $numero = !empty($documento['numero_esterno']) ? $documento['numero_esterno'] : $documento['numero'];
+                            $qta = $documento['qta_ordinata'];
+                            echo '
+                            <tr>';
+                                if ($gestisciMagazzini['valore'] == '1') {
+                                    $ordinatoPerSede[$documento['id_sede_partenza']] += $qta;
 
-    $modulo = Modules::get('Ordini fornitore');
-    foreach ($ordini as $documento) {
-        $numero = !empty($documento['numero_esterno']) ? $documento['numero_esterno'] : $documento['numero'];
-        $qta = $documento['qta_ordinata'];
+                                    echo
+                                    '<td>
+                                        <small>
+                                            '.$documento['Magazzino'].'
+                                        </small>
+                                    </td>';
+                                }
+                                echo
+                                '<td>
+                                    <small>
+                                        '.Modules::link($modulo['id'], $documento['id'], tr('Ordine num. _NUM_ del _DATE_', [
+                                            '_NUM_' => $numero,
+                                            '_DATE_' => dateFormat($documento['data']),
+                                        ])).'
+                                        </small>
+                                </td>
+                                <td class="text-right">
+                                    <small>'.numberFormat($qta, 2).'</small>
+                                </td>
+                            </tr>';
+                        }
+                        echo '
+                        <tr>';
+                            if ($gestisciMagazzini['valore'] == '1') {
+                                echo
+                                '<td></td>';
+                            }
+                            echo
+                            '<td class="text-right">
+                                <small><b>'.tr('Totale').'</b></small>
+                            </td>
+                            <td class="text-right">
+                                <small>'.numberFormat($ordinato, 2).'</small>
+                            </td>
+                        </tr>
+                </table>';
+            } else {
+                echo '
+                <p>'.tr('Nessun ordine fornitore con quantità da evadere individuato').'.</p>';
+            }
+            echo '
+            </div>
+		</div>
+	</div>';
+
+    /**
+     * Da ordinare.
+     */
+
+    if ($gestisciMagazzini['valore'] == '1') {
+        echo
+        '<div class="col-md-3">
+            <div class="panel panel-primary">
+                <div class="panel-heading">
+                    <h3 class="panel-title">'.tr('Da ordinare').'<span class="tip pull-right" title="'.tr('Quantità richieste dal cliente meno le quantità già ordinate.').'">
+                    <i class="fa fa-question-circle-o"></i></span></h3>
+                </div>
+                <div class="panel-body" style="min-height:98px;">
+                    <table class="table table-bordered table-condensed table-striped">
+                        <thead>
+                            <tr>
+                                <th>'.tr('Magazzino').'</th>
+                                <th class="text-right" style="min-width:50px">'.$record['um'].'</th>
+                            </tr>
+                        </thead>
+                        <tbody>';
+                            foreach ($sedi as $sede) {
+                                $articoloSede = $dbo->fetchOne(
+                                    'SELECT threshold_qta, id_sede
+                                    FROM mg_articoli_sedi
+                                    WHERE id_articolo = '.prepare($id_record).'
+                                    AND id_sede = '.prepare($sede['id'])
+                                );
+
+                                $qta_presente = $giacenze[$sede['id']][0] > 0 ? $giacenze[$sede['id']][0] : 0;
+                                $diff = (intval($qta_presente) - intval($impegnatoPerSede[$sede['id']]) +
+                                            intval($ordinatoPerSede[$sede['id']]) - intval($articoloSede['threshold_qta'])) * -1;
+
+                                $da_ordinare = (($diff <= 0) ? 0 : $diff);
+
+                                echo
+                                '<tr>
+                                    <td>
+                                        <small>
+                                            '.$sede['nomesede'].'
+                                        </small>
+                                    </td>
+                                    <td>
+                                        <small>
+                                            '.numberFormat($da_ordinare, 2).'
+                                            <span class="tip pull-right" title="
+                                                <table>
+                                                    <tbody>
+                                                        <tr>
+                                                            <td>'.tr('Quantità presente: ').'</td>
+                                                            <td>'.numberFormat($qta_presente, 2).' '.$articolo->um.'</td>
+                                                            <td>-</td>
+                                                        </tr>
+                                                        <tr>
+                                                            <td>'.tr('Impegnato: ').'</td>
+                                                            <td>'.numberFormat($impegnatoPerSede[$sede['id']], 2).' '.$articolo->um.'</td>
+                                                            <td>+</td>
+                                                        </tr>
+                                                        <tr>
+                                                            <td>'.tr('Ordinato: ').'</td>
+                                                            <td>'.numberFormat($ordinatoPerSede[$sede['id']], 2).' '.$articolo->um.'</td>
+                                                            <td>-</td>
+                                                        </tr>
+                                                        <tr>
+                                                            <td>'.tr('Soglia minima: ').'</td>
+                                                            <td>'.numberFormat($articoloSede['threshold_qta'], 2).' '.$articolo->um.'</td>
+                                                            <td>=</td>
+                                                        </tr>
+                                                        <tr>
+                                                            <td></td>
+                                                            <td>'.numberFormat($da_ordinare, 2).' '.$articolo->um.'</td>
+                                                            <td></td>
+                                                        </tr>
+                                                    </tbody>
+                                                </table>
+                                            ">
+                                                <i class="fa fa-question-circle-o"></i>
+                                            </span>
+                                        </small>
+                                    </td>
+                                </tr>';
+                            }
+                        echo
+                        '</tbody>
+                    </table>
+                </div>
+            </div>
+        </div>';
+    } else {
+        $qta_presente = $articolo->qta > 0 ? $articolo->qta : 0;
+        $diff = ($qta_presente - $impegnato + $ordinato) * -1;
+        $da_ordinare = (($diff <= 0) ? 0 : $diff);
 
         echo '
-                    <tr>
-                        <td>
-                            <small>
-                                '.Modules::link($modulo['id'], $documento['id'], tr('Ordine num. _NUM_ del _DATE_', [
-                                    '_NUM_' => $numero,
-                                    '_DATE_' => dateFormat($documento['data']),
-                                ])).'
-                                </small>
-                        </td>
-                        <td class="text-right">
-                            <small>'.numberFormat($qta).'</small>
-                        </td>
-                    </tr>';
+        <div class="col-md-3">
+            <div class="panel panel-primary">
+                <div class="panel-heading">
+                    <h3 class="panel-title">'.tr('Da ordinare').'<span class="tip pull-right" title="'.tr('Quantità richieste dal cliente meno le quantità già ordinate.').'">
+                    <i class="fa fa-question-circle-o"></i></span></h3>
+                </div>
+                <div class="panel-body">
+                <div class="row">
+                    <div class="col-md-12 text-center" style="font-size:35pt;">
+                        '.numberFormat($da_ordinare, 2).' '.$articolo->um.'
+                    </div>
+                </div>
+                </div>
+            </div>
+        </div>';
     }
 
+    /**
+    * Disponibile.
+    */
+    $qta_presente = $articolo->qta > 0 ? $articolo->qta : 0;
+    $disponibile = $qta_presente - $impegnato;
+
     echo '
-                    <tr>
-                        <td class="text-right">
-                            <small><b>'.tr('Totale').'</b></small>
-                        </td>
-                        <td class="text-right">
-                            <small>'.numberFormat($ordinato).'</small>
-                        </td>
-                    </tr>
-
-                </table>';
-} else {
-    echo '
-                <p>'.tr('Nessun ordine fornitore con quantità da evadere individuato').'.</p>';
-}
-
-echo '
-			</div>
-		</div>
-	</div>';
-
-/**
- ** Da ordinare.
- */
-$qta_presente = $articolo->qta > 0 ? $articolo->qta : 0;
-$diff = ($qta_presente - $impegnato + $ordinato) * -1;
-$da_ordinare = (($diff <= 0) ? 0 : $diff);
-
-echo '
-	<div class="col-md-3">
-		<div class="panel panel-primary">
-			<div class="panel-heading">
-				<h3 class="panel-title">'.tr('Da ordinare').'<span class="tip pull-right" title="'.tr('Quantità richieste dal cliente meno le quantità già ordinate.').'">
+    <div class="col-md-3">
+        <div class="panel panel-primary">
+            <div class="panel-heading">
+                <h3 class="panel-title">'.tr('Disponibile').'<span class="tip pull-right" title="'.tr('Quantità disponibili nel magazzino.').'">
                 <i class="fa fa-question-circle-o"></i></span></h3>
-			</div>
-			<div class="panel-body">
-              <div class="row">
-                 <div class="col-md-12 text-center" style="font-size:35pt;">
-                       '.numberFormat($da_ordinare).' '.$articolo->um.'
-			       </div>
-			   </div>
-			</div>
-		</div>
-	</div>';
+            </div>
+            <div class="panel-body">
 
-/**
- ** Disponibile.
- */
-$disponibile = $qta_presente - $impegnato;
-echo '
-	<div class="col-md-3">
-		<div class="panel panel-primary">
-			<div class="panel-heading">
-				<h3 class="panel-title">'.tr('Disponibile').'<span class="tip pull-right" title="'.tr('Quantità disponibili nel magazzino.').'">
-                <i class="fa fa-question-circle-o"></i></span></h3>
-			</div>
-			<div class="panel-body">
+            <div class="row">
+                <div class="col-md-12 text-center" style="font-size:35pt;">
+                    '.numberFormat($disponibile, 2).' '.$articolo->um.'
+                </div>
+            </div>
 
-              <div class="row">
-                 <div class="col-md-12 text-center" style="font-size:35pt;">
-                       '.numberFormat($disponibile).' '.$articolo->um.'
-			       </div>
-			   </div>
-
-			</div>
-		</div>
-	</div>
+            </div>
+        </div>
+    </div>
 </div>';
 
-$sedi = $dbo->fetchArray('(SELECT "0" AS id, IF(indirizzo!=\'\', CONCAT_WS(" - ", "'.tr('Sede legale').'", CONCAT(citta, \' (\', indirizzo, \')\')), CONCAT_WS(" - ", "'.tr('Sede legale').'", citta)) AS nomesede FROM an_anagrafiche WHERE idanagrafica = '.prepare(setting('Azienda predefinita')).') UNION (SELECT id, IF(indirizzo!=\'\',CONCAT_WS(" - ", nomesede, CONCAT(citta, \' (\', indirizzo, \')\')), CONCAT_WS(" - ", nomesede, citta )) AS nomesede FROM an_sedi WHERE idanagrafica='.prepare(setting('Azienda predefinita')).')');
-$giacenze = $articolo->getGiacenze();
-
+/**
+ * Giacenze
+ */
 echo '
 <div class="row">
     <div class="col-md-12">
@@ -266,20 +439,18 @@ echo '
                     </thead>
 
                     <tbody>';
-
-foreach ($sedi as $sede) {
-    echo '
-                        <tr>
-                            <td>'.$sede['nomesede'].'</td>
-                            <td class="text-right">'.numberFormat($giacenze[$sede['id']][0]).' '.$articolo->um.'</td>
-                            <td class="text-center">
-                                <a class="btn btn-xs btn-info" title="Dettagli" onclick="getDettagli('.$sede['id'].');">
-                                    <i class="fa fa-eye"></i>
-                                </a>
-                            </td>
-                        </tr>';
-}
-
+                        foreach ($sedi as $sede) {
+                            echo '
+                            <tr>
+                                <td>'.$sede['nomesede'].'</td>
+                                <td class="text-right">'.numberFormat($giacenze[$sede['id']][0], 2).' '.$articolo->um.'</td>
+                                <td class="text-center">
+                                    <a class="btn btn-xs btn-info" title="Dettagli" onclick="getDettagli('.$sede['id'].');">
+                                        <i class="fa fa-eye"></i>
+                                    </a>
+                                </td>
+                            </tr>';
+                        }
                     echo '
                     </tbody>
                 </table>

--- a/modules/ordini/actions.php
+++ b/modules/ordini/actions.php
@@ -43,11 +43,12 @@ switch (post('op')) {
         $idanagrafica = post('idanagrafica');
         $data = post('data');
         $id_segment = post('id_segment');
+        $id_sede_partenza = post('id_sede_partenza');
 
         $anagrafica = Anagrafica::find($idanagrafica);
         $tipo = Tipo::where('dir', $dir)->first();
 
-        $ordine = Ordine::build($anagrafica, $tipo, $data, $id_segment);
+        $ordine = Ordine::build($anagrafica, $tipo, $data, $id_segment, $id_sede_partenza);
         $id_record = $ordine->id;
 
         flash()->info(tr('Aggiunto ordine numero _NUM_!', [
@@ -61,6 +62,7 @@ switch (post('op')) {
             $idstatoordine = post('idstatoordine');
             $idpagamento = post('idpagamento');
             $idsede = post('idsede');
+            $id_sede_partenza = post('id_sede_partenza');
 
             $totale_imponibile = get_imponibile_ordine($id_record);
             $totale_ordine = get_totale_ordine($id_record);
@@ -92,6 +94,7 @@ switch (post('op')) {
             $ordine->idstatoordine = $idstatoordine;
             $ordine->idpagamento = $idpagamento;
             $ordine->idsede = $idsede;
+            $ordine->id_sede_partenza = $id_sede_partenza;
             $ordine->idconto = post('idconto');
             $ordine->idrivalsainps = $idrivalsainps;
             $ordine->idritenutaacconto = $idritenutaacconto;
@@ -332,7 +335,7 @@ switch (post('op')) {
     // Scollegamento riga generica da ordine
     case 'delete_riga':
         $id_righe = (array)post('righe');
-        
+
         foreach ($id_righe as $id_riga) {
             $riga = Articolo::find($id_riga) ?: Riga::find($id_riga);
             $riga = $riga ?: Descrizione::find($id_riga);
@@ -356,7 +359,7 @@ switch (post('op')) {
     // Duplicazione riga
     case 'copy_riga':
         $id_righe = (array)post('righe');
-        
+
         foreach ($id_righe as $id_riga) {
             $riga = Articolo::find($id_riga) ?: Riga::find($id_riga);
             $riga = $riga ?: Descrizione::find($id_riga);
@@ -424,7 +427,9 @@ switch (post('op')) {
         if (post('create_document') == 'on') {
             $tipo = Tipo::where('dir', $documento->direzione)->first();
 
-            $ordine = Ordine::build($documento->anagrafica, $tipo, post('data'), post('id_segment'));
+            $id_sede_partenza = post('id_sede_partenza');
+
+            $ordine = Ordine::build($documento->anagrafica, $tipo, post('data'), post('id_segment'), $id_sede_partenza);
             $ordine->idpagamento = $documento->idpagamento;
             $ordine->idsede = $id_sede;
 
@@ -483,8 +488,9 @@ switch (post('op')) {
         if (post('create_document') == 'on') {
             $anagrafica = Anagrafica::find(post('idanagrafica'));
             $tipo = Tipo::where('dir', $dir)->first();
+            $id_sede_partenza = post('id_sede_partenza');
 
-            $ordine = Ordine::build($anagrafica, $tipo, post('data'), post('id_segment'));
+            $ordine = Ordine::build($anagrafica, $tipo, post('data'), post('id_segment'), $id_sede_partenza);
             $ordine->save();
 
             $id_record = $ordine->id;
@@ -548,8 +554,9 @@ switch (post('op')) {
         if (post('create_document') == 'on') {
             $anagrafica = Anagrafica::find(post('idanagrafica'));
             $tipo = Tipo::where('dir', $dir)->first();
+            $id_sede_partenza = post('id_sede_partenza');
 
-            $ordine = Ordine::build($anagrafica, $tipo, post('data'), post('id_segment'));
+            $ordine = Ordine::build($anagrafica, $tipo, post('data'), post('id_segment'), $id_sede_partenza);
             $ordine->save();
 
             $id_record = $ordine->id;

--- a/modules/ordini/ajax/select.php
+++ b/modules/ordini/ajax/select.php
@@ -48,4 +48,39 @@ switch ($resource) {
         }
 
         break;
+
+    case 'sedi-partenza':
+        $gestisciMagazzini = $dbo->fetchOne('SELECT * FROM zz_settings WHERE nome = "Gestisci soglia minima per magazzino"');
+
+        if ($gestisciMagazzini['valore'] == '1') {
+            $query = '(
+                    SELECT "0" AS id,
+                    IF(
+                        indirizzo != "",
+                        CONCAT_WS(" - ", "Sede legale", CONCAT(citta, " (", indirizzo, ")")),
+                        CONCAT_WS(" - ", "Sede legale", citta)
+                    ) AS descrizione
+                    FROM an_anagrafiche WHERE idanagrafica = "1"
+                ) UNION (
+                    SELECT id,
+                    IF(
+                        indirizzo != "",
+                        CONCAT_WS(" - ", nomesede, CONCAT(citta, " (", indirizzo, ")")),
+                        CONCAT_WS(" - ", nomesede, citta )
+                    ) AS descrizione
+                    FROM an_sedi WHERE idanagrafica="1"
+                )';
+            } else {
+                $query = '(
+                    SELECT "0" AS id,
+                    IF(
+                        indirizzo != "",
+                        CONCAT_WS(" - ", "Sede legale", CONCAT(citta, " (", indirizzo, ")")),
+                        CONCAT_WS(" - ", "Sede legale", citta)
+                    ) AS descrizione
+                    FROM an_anagrafiche WHERE idanagrafica = "1"
+                )';
+            }
+
+        break;
 }

--- a/modules/ordini/src/Ordine.php
+++ b/modules/ordini/src/Ordine.php
@@ -51,7 +51,7 @@ class Ordine extends Document
      *
      * @return self
      */
-    public static function build(Anagrafica $anagrafica, Tipo $tipo_documento, $data, $id_segment = null)
+    public static function build(Anagrafica $anagrafica, Tipo $tipo_documento, $data, $id_segment = null, $id_sede_partenza = 0)
     {
         $model = new static();
 
@@ -82,6 +82,7 @@ class Ordine extends Document
         $model->tipo()->associate($tipo_documento);
         $model->stato()->associate($stato_documento);
         $model->id_segment = $id_segment;
+        $model->id_sede_partenza = $id_sede_partenza;
 
         $model->save();
 
@@ -92,7 +93,7 @@ class Ordine extends Document
             $model->idpagamento = $id_pagamento;
         }
 
-        $model->numero = static::getNextNumero($data, $direzione, $id_segment);
+        $model->numero = static::getNextNumero($data, $direzione);
         $model->numero_esterno = static::getNextNumeroSecondario($data, $direzione, $id_segment);
 
         $model->save();


### PR DESCRIPTION
## Descrizione

E' possibile indicare in impostazioni>magazzino la gestione della soglie minime nei magazzini

Nel caso le si volessero gestire è possibile indicare in ogni articolo la soglia minima che deve essere presente in ogni magazzino


E' stato poi di conseguenza modificato il plugin giacenze

![4](https://user-images.githubusercontent.com/80101758/227516570-b0b47093-48e9-4b12-b853-0b6de657d9e7.png)


Inoltre sono state gestite le sedi di partenza nell'ordine e alla selezione di un articolo da inserire in una vendita vengono mostrate le giacenze per magazzino.

Inoltre è stata aggiunta la possibilità di aggiungere gli articoli attraverso un file di barcode formato da righe del tipo _barcode_;_qta_


![5](https://user-images.githubusercontent.com/80101758/227516499-b0f25fb2-77d8-4c9c-a2c5-e339267d39c2.png)

## Tipologia

Rimuovi le opzioni non rilevanti.

- [ ] Bug fix (cambiamenti minori che risolvono una issue)
- [x] Nuova funzionalità (cambiamenti minori che aggiungono una nuova funzionalità)
- [ ] Cambiamento maggiore (fix o funzionalità che richiede una revisione prima di essere pubblicata)
- [x] Questo cambiamenti richiede un aggiornamento della documentazione

# Checklist

- [x] Il codice segue le linee guida del progetto
- [ ] Ho commentato il codice, in particolare nelle parti più complesse
- [ ] Ho aggiornato di conseguenza la documentazione (se presente)
- [x] Il codice non genera warnings
