### PR TITLE
Ottimizzazione tabella zz_task_logs

### DIFF
--- a/src/Tasks/Task.php
+++ b/src/Tasks/Task.php
@@ -46,15 +46,17 @@ class Task extends Model
 
     public function log($level, $message, $context = [])
     {
-        $log = new Log();
-
-        $log->level = $level;
-        $log->message = $message;
-        $log->context = $context;
-
-        $log->task()->associate($this);
-
-        $log->save();
+        if (!empty($context)) {
+            $log = new Log();
+    
+            $log->level = $level;
+            $log->message = $message;
+            $log->context = $context;
+    
+            $log->task()->associate($this);
+    
+            $log->save();
+        }
     }
 
     public function execute()


### PR DESCRIPTION
## Descrizione

Ottimizzazione tabella zz_task_logs, evitando di scrivere i log se l'output è vuoto, come suggerito nella issue #1579.

Risolve: #1579 