### PR TITLE
fix #1648

### DIFF
--- a/modules/statistiche/edit.php
+++ b/modules/statistiche/edit.php
@@ -41,13 +41,15 @@ $start_date = new DateTime($start);
 $end_date = new DateTime($end);
 
 while ($start_date <= $end_date) {
-    $months[] = $start_date->format('F');
-    $start_date->modify('+1 month');
+    $month_number = $start_date->format('n');  // Ottiene il numero del mese (1-12)
+    if (!in_array($month_number, $months)) {  // Aggiunge il mese solo se non gia' presente
+        $months[] = $month_number;
+    }
+    $start_date->modify('+1 month');  // Avanza al mese successivo
 }
-
-foreach ($months as $key => $month) {
-    $month_number = date('n', strtotime($month));
-    $months[$key] = $translated_months[$month_number - 1];
+// Sostituisce i numeri con i nomi tradotti
+foreach ($months as $key => $month_number) {
+    $months[$key] = $translated_months[$month_number - 1];  // Traduce il mese
 }
 
 // Fatturato


### PR DESCRIPTION
## Descrizione
Risolve l'errore per cui venivano stampati mesi duplicati nelle tabelle. 

Risolve: #(issue)
#1648
## Tipologia

Rimuovi le opzioni non rilevanti.

- [ ] Bug fix (cambiamenti minori che risolvono una issue)
