### PR TITLE
fix: corregge la base image Docker inesistente (php:8.5-apache-bullseye)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.5-apache-bullseye
+FROM php:8.5-apache-bookworm
 
 ENV DEBIAN_FRONTEND=noninteractive \
     LAST_VERSION_URL="https://api.github.com/repos/devcode-it/openstamanager/releases/latest" \


### PR DESCRIPTION
## Descrizione

Il tag immagine `php:8.5-apache-bullseye` usato come base in `docker/Dockerfile` non esiste su Docker Hub: per PHP 8.5 non viene pubblicata alcuna variante `bullseye` (Debian 11). Di conseguenza il build dell'immagine Docker fallisce con un errore *manifest unknown / image not found*.

Le uniche varianti `8.5-apache` disponibili sono: `8.5-apache`, `8.5-apache-bookworm` (Debian 12) e `8.5-apache-trixie` (Debian 13).

La modifica imposta come base `php:8.5-apache-bookworm`, scelto come sostituto conservativo di bullseye (Debian stable corrente). Nessuna dipendenza aggiuntiva richiesta: tutti i pacchetti `apt` e le estensioni PHP utilizzate nel Dockerfile sono disponibili su bookworm.

Nessuna issue associata.

## Tipologia

- [x] Bug fix (cambiamenti minori che risolvono una issue)

# Checklist

- [x] Il codice segue le linee guida del progetto
- [x] Il codice non genera warnings