### PR TITLE
fix(docker): base image php:8.5 bookworm + JRE per openapi-generator-cli

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,6 +6,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
+    default-jre-headless \
     libcurl4-openssl-dev \
     libicu-dev \
     libonig-dev \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.5-apache-bullseye
+FROM php:8.5-apache-bookworm
 
 ENV DEBIAN_FRONTEND=noninteractive \
     LAST_VERSION_URL="https://api.github.com/repos/devcode-it/openstamanager/releases/latest" \


### PR DESCRIPTION
## Descrizione

Il build dell'immagine Docker fallisce su `master` per due motivi distinti, entrambi risolti in questa PR:

1. **Base image inesistente** — `php:8.5-apache-bullseye` non esiste su Docker Hub (per PHP 8.5 non è pubblicata la variante `bullseye`), e il build fallisce con un errore *image not found*. Si passa a `php:8.5-apache-bookworm` (Debian 12 stable), disponibile per `8.5-apache`.
2. **Runtime Java mancante** — il passo `npm run build-OSM` esegue `openapi-generator-cli generate`, uno strumento Java, ma l'immagine non includeva alcun runtime Java: il build fallisce con `Error: /bin/sh: 1: java: not found`.

Dipendenze aggiuntive: viene aggiunto il pacchetto di sistema `default-jre-headless` tra le dipendenze installate via `apt-get`.

## Tipologia

- [x] Bug fix (cambiamenti minori che risolvono una issue)

# Checklist

- [x] Il codice segue le linee guida del progetto
- [x] Il codice non genera warnings