### PR TITLE
fix(import): pass escape arg to fputcsv in CSV example generation

### DIFF
--- a/src/Importer/CSVImporter.php
+++ b/src/Importer/CSVImporter.php
@@ -224,7 +224,7 @@ abstract class CSVImporter implements ImporterInterface
         fprintf($file, chr(0xEF).chr(0xBB).chr(0xBF));
 
         foreach ($content as $row) {
-            fputcsv($file, $row, ';');
+            fputcsv($file, $row, ';', escape: '\\');
         }
 
         fclose($file);


### PR DESCRIPTION
## Descrizione

Il pulsante **"Scarica esempio CSV"** nel modulo Importazioni restituisce una pagina **404 / Not Found** anziché scaricare il file di esempio.

Causa: su **PHP 8.4+** la chiamata `fputcsv()` senza il parametro `$escape` emette un `E_DEPRECATED` (*"the $escape parameter must be provided as its default value will change"*). Poiché `core.php` registra **Whoops** come gestore degli errori, la deprecazione viene promossa a eccezione e interrompe `CSVImporter::createExample()`. Il modulo `import` cattura l'eccezione e restituisce un JSON di errore che il frontend (`window.location = data`) tenta di aprire come URL, generando il 404.

Fix: passare esplicitamente `escape: '\\'` a `fputcsv()` in `createExample()`, mantenendo il comportamento storico (PHP ≤ 8.3) e silenziando la deprecazione.

Nessuna dipendenza aggiuntiva.

Risolve: #(nessuna issue collegata)

## Tipologia

- [x] Bug fix (cambiamenti minori che risolvono una issue)

# Checklist

- [x] Il codice segue le linee guida del progetto
- [x] Ho commentato il codice, in particolare nelle parti più complesse
- [ ] Ho aggiornato di conseguenza la documentazione (se presente)
- [x] Il codice non genera warnings
