### PR TITLE
fix: provide legacy escape to fputcsv() for PHP 8.4/8.5

### DIFF
--- a/modules/anagrafiche/bulk.php
+++ b/modules/anagrafiche/bulk.php
@@ -176,7 +176,7 @@ switch (post('op')) {
         $handle = fopen($file, 'w');
 
         // Scrittura dell'intestazione
-        fputcsv($handle, ['email', 'ragione_sociale', 'fonte', 'sede_referente'], ';');
+        fputcsv($handle, ['email', 'ragione_sociale', 'fonte', 'sede_referente'], ';', escape: '\\');
 
         // Scrittura dei dati
         foreach ($results as $row) {
@@ -185,7 +185,7 @@ switch (post('op')) {
                 $row['ragione_sociale'],
                 $row['fonte'],
                 $row['sede_referente'],
-            ], ';');
+            ], ';', escape: '\\');
         }
         fclose($handle);
 

--- a/modules/articoli/src/Import/CSV.php
+++ b/modules/articoli/src/Import/CSV.php
@@ -619,12 +619,12 @@ class CSV extends CSVImporter
 
         $header = $this->getHeader();
         $header[] = 'Errore';
-        fputcsv($file, $header, ';');
+        fputcsv($file, $header, ';', escape: '\\');
 
         foreach ($this->failed_rows as $index => $row) {
             $error_message = $this->failed_errors[$index] ?? 'Errore sconosciuto';
             $row[] = $error_message;
-            fputcsv($file, $row, ';');
+            fputcsv($file, $row, ';', escape: '\\');
         }
 
         fclose($file);

--- a/modules/impianti/src/Import/CSV.php
+++ b/modules/impianti/src/Import/CSV.php
@@ -234,12 +234,12 @@ class CSV extends CSVImporter
 
         $header = $this->getHeader();
         $header[] = 'Errore';
-        fputcsv($file, $header, ';');
+        fputcsv($file, $header, ';', escape: '\\');
 
         foreach ($this->failed_rows as $index => $row) {
             $error_message = $this->failed_errors[$index] ?? 'Errore sconosciuto';
             $row[] = $error_message;
-            fputcsv($file, $row, ';');
+            fputcsv($file, $row, ';', escape: '\\');
         }
 
         fclose($file);

--- a/modules/liste_newsletter/actions.php
+++ b/modules/liste_newsletter/actions.php
@@ -146,7 +146,7 @@ switch (filter('op')) {
         $handle = fopen($file, 'w');
 
         // Scrittura dell'intestazione
-        fputcsv($handle, ['Email', 'Ragione sociale'], ';');
+        fputcsv($handle, ['Email', 'Ragione sociale'], ';', escape: '\\');
 
         // Scrittura dei dati
         foreach ($results as $destinatario) {
@@ -156,7 +156,7 @@ switch (filter('op')) {
             fputcsv($handle, [
                 $origine->email,
                 $anagrafica->ragione_sociale,
-            ], ';');
+            ], ';', escape: '\\');
         }
         fclose($handle);
 

--- a/modules/listini_cliente/src/Import/CSV.php
+++ b/modules/listini_cliente/src/Import/CSV.php
@@ -229,12 +229,12 @@ class CSV extends CSVImporter
 
         $header = $this->getHeader();
         $header[] = 'Errore';
-        fputcsv($file, $header, ';');
+        fputcsv($file, $header, ';', escape: '\\');
 
         foreach ($this->failed_rows as $index => $row) {
             $error_message = $this->failed_errors[$index] ?? 'Errore sconosciuto';
             $row[] = $error_message;
-            fputcsv($file, $row, ';');
+            fputcsv($file, $row, ';', escape: '\\');
         }
 
         fclose($file);

--- a/src/Importer/CSVImporter.php
+++ b/src/Importer/CSVImporter.php
@@ -224,7 +224,7 @@ abstract class CSVImporter implements ImporterInterface
         fprintf($file, chr(0xEF).chr(0xBB).chr(0xBF));
 
         foreach ($content as $row) {
-            fputcsv($file, $row, ';');
+            fputcsv($file, $row, ';', escape: '\\');
         }
 
         fclose($file);
@@ -348,14 +348,14 @@ abstract class CSVImporter implements ImporterInterface
             // Scrivi l'intestazione con colonna errore
             $header = $this->getHeader();
             $header[] = 'Errore';
-            fputcsv($file, $header, ';');
+            fputcsv($file, $header, ';', escape: '\\');
         }
 
         // Scrivi le righe fallite con errore
         foreach ($this->failed_rows as $index => $row) {
             $error_message = $this->failed_errors[$index] ?? 'Errore sconosciuto';
             $row[] = $error_message;
-            fputcsv($file, $row, ';');
+            fputcsv($file, $row, ';', escape: '\\');
         }
 
         fclose($file);


### PR DESCRIPTION
## Descrizione

A partire da PHP 8.4 chiamare `fputcsv()` senza il parametro `$escape` esplicito è deprecato, perché il valore di default cambierà in PHP 8.5. Su PHP 8.5 questo genera un errore visibile all'utente durante l'import/export CSV:

> `fputcsv(): the $escape parameter must be provided as its default value will change`

Questa modifica passa l'escape legacy (`escape: '\\'`) a tutte le chiamate `fputcsv()` del progetto, preservando il comportamento di escaping attuale e silenziando la deprecazione. Nessuna modifica funzionale.

File toccati:
- `src/Importer/CSVImporter.php` (CSV di esempio e report delle righe fallite durante l'import)
- `modules/articoli/src/Import/CSV.php`
- `modules/listini_cliente/src/Import/CSV.php`
- `modules/impianti/src/Import/CSV.php`
- `modules/liste_newsletter/actions.php`
- `modules/anagrafiche/bulk.php`

Nessuna dipendenza aggiuntiva richiesta.

Risolve: nessuna issue collegata.

## Tipologia

- [x] Bug fix (cambiamenti minori che risolvono una issue)

# Checklist

- [x] Il codice segue le linee guida del progetto
- [ ] Ho commentato il codice, in particolare nelle parti più complesse
- [ ] Ho aggiornato di conseguenza la documentazione (se presente)
- [x] Il codice non genera warnings
