### PR TITLE
perf+feat(import): fix O(n^2) CSV read, smaller batch, progress bar

### DIFF
--- a/modules/import/actions.php
+++ b/modules/import/actions.php
@@ -88,7 +88,8 @@ switch (filter('op')) {
             $fields = (array) post('fields');
             $page = post('page');
 
-            $limit = 500;
+            // Batch piccolo: richieste brevi (margine sui timeout/504) e progress più fluida
+            $limit = 100;
 
             // Inizializzazione del lettore CSV
             $filepath = base_dir().'/files/'.$record->directory.'/'.$record->filename;

--- a/modules/import/edit.php
+++ b/modules/import/edit.php
@@ -234,10 +234,34 @@ if (empty($id_record)) {
     </div>
 </form>';
 
+    // Totale record del CSV (intestazione inclusa): serve alla progress bar lato client
+    $totale_record = $csv->getTotalRows();
+
+    echo '
+<div id="import-progress-overlay" style="display:none; position:fixed; top:0; left:0; right:0; bottom:0; z-index:99999; background:rgba(255,255,255,0.92); flex-direction:column; justify-content:center; align-items:center;">
+    <div style="width:60%; max-width:600px;">
+        <h4 class="text-center" style="margin-bottom:15px;">'.tr('Importazione in corso...').'</h4>
+        <div class="progress" style="height:28px;">
+            <div id="import-progress-bar" class="progress-bar progress-bar-striped progress-bar-animated bg-primary" role="progressbar" style="width:0%; line-height:28px;">0%</div>
+        </div>
+        <div id="import-progress-label" class="text-center text-muted" style="margin-top:8px;"></div>
+    </div>
+</div>';
+
     echo '
 <script>
 var count = 0;
 var failed_records_filename = null;  // Variabile globale per mantener il nome del file di errore tra batch
+var importTotalRecords = '.$totale_record.';  // record totali nel CSV (intestazione inclusa)
+var importTotalRows = 0;                       // righe dati effettive da importare
+var importProcessed = 0;                       // righe processate finora (importate + fallite)
+
+function updateImportProgress() {
+    var pct = importTotalRows > 0 ? Math.min(100, Math.round(importProcessed / importTotalRows * 100)) : 0;
+    var done = Math.min(importProcessed, importTotalRows);
+    $("#import-progress-bar").css("width", pct + "%").text(pct + "%");
+    $("#import-progress-label").text(done + " / " + importTotalRows + " '.tr('righe').'");
+}
 
 $(document).ready(function() {';
 
@@ -256,6 +280,12 @@ $(document).ready(function() {';
     save.on("click", function() {
         count = 0;
         failed_records_filename = null;  // Reset della variabile
+
+        // Avanzamento: se la prima riga non viene importata è l\'intestazione, quindi va esclusa dal totale
+        importProcessed = 0;
+        importTotalRows = $("#include_first_row").is(":checked") ? importTotalRecords : Math.max(0, importTotalRecords - 1);
+        updateImportProgress();
+
         importPage(0);
     });
 });
@@ -279,7 +309,7 @@ function importPage(page) {
         }
     }
 
-    $("#main_loading").show();
+    $("#import-progress-overlay").css("display", "flex");
 
     let data = {
         id_module: "'.$id_module.'",
@@ -302,7 +332,7 @@ function importPage(page) {
 
             // Gestione errori di validazione
             if (data.error) {
-                $("#main_loading").fadeOut();
+                $("#import-progress-overlay").hide();
 
                 Swal.fire({
                     title: "'.tr('Errore').'",
@@ -321,11 +351,17 @@ function importPage(page) {
             // Aggiorna i contatori
             count += data.imported;
 
+            // Avanzamento: somma le righe processate in questo batch (importate + fallite)
+            importProcessed += data.total;
+            updateImportProgress();
+
             // Se ci sono altre pagine da importare
             if(data.more) {
                 importPage(page + 1);
             } else {
-                $("#main_loading").fadeOut();
+                importProcessed = importTotalRows;
+                updateImportProgress();
+                $("#import-progress-overlay").hide();
 
                 // Prepara il messaggio di completamento
                 let title = "'.tr('Importazione completata').'";
@@ -399,10 +435,16 @@ function importPage(page) {
                 }
             }
         },
-        error: function(data) {
-            $("#main_loading").fadeOut();
+        error: function(xhr) {
+            $("#import-progress-overlay").hide();
 
-            alert("'.tr('Errore').': " + data);
+            var message = (xhr && xhr.responseJSON && xhr.responseJSON.message) || (xhr && xhr.responseText) || (xhr && xhr.statusText) || "'.tr('Errore sconosciuto').'";
+
+            Swal.fire({
+                title: "'.tr('Errore').'",
+                text: message,
+                icon: "error",
+            });
         }
     });
 };

--- a/modules/import/edit.php
+++ b/modules/import/edit.php
@@ -245,6 +245,9 @@ if (empty($id_record)) {
             <div id="import-progress-bar" class="progress-bar progress-bar-striped progress-bar-animated bg-primary" role="progressbar" style="width:0%; line-height:28px;">0%</div>
         </div>
         <div id="import-progress-label" class="text-center text-muted" style="margin-top:8px;"></div>
+        <div class="text-center" style="margin-top:18px; color:#b8860b; font-weight:600;">
+            <i class="fa fa-exclamation-triangle"></i> '.tr('Non chiudere né ricaricare questa pagina finché l\'importazione non è completata: interrompendola, alcune righe potrebbero non essere importate.').'
+        </div>
     </div>
 </div>';
 

--- a/modules/import/edit.php
+++ b/modules/import/edit.php
@@ -237,6 +237,10 @@ if (empty($id_record)) {
     // Totale record del CSV (intestazione inclusa): serve alla progress bar lato client
     $totale_record = $csv->getTotalRows();
 
+    // La geolocalizzazione automatica (solo anagrafiche) fa una chiamata online per ogni riga:
+    // se attiva, l'importazione è più lenta e lo segnaliamo nell'overlay di avanzamento.
+    $geoloc_attiva = $import_selezionato === CSV::class && setting('Geolocalizzazione automatica');
+
     echo '
 <div id="import-progress-overlay" style="display:none; position:fixed; top:0; left:0; right:0; bottom:0; z-index:99999; background:rgba(255,255,255,0.92); flex-direction:column; justify-content:center; align-items:center;">
     <div style="width:60%; max-width:600px;">
@@ -247,7 +251,10 @@ if (empty($id_record)) {
         <div id="import-progress-label" class="text-center text-muted" style="margin-top:8px;"></div>
         <div class="text-center" style="margin-top:18px; color:#b8860b; font-weight:600;">
             <i class="fa fa-exclamation-triangle"></i> '.tr('Non chiudere né ricaricare questa pagina finché l\'importazione non è completata: interrompendola, alcune righe potrebbero non essere importate.').'
-        </div>
+        </div>'.($geoloc_attiva ? '
+        <div class="text-center" style="margin-top:12px; color:#6c757d;">
+            <i class="fa fa-clock-o"></i> '.tr('La geolocalizzazione automatica delle anagrafiche è attiva: ogni riga viene geolocalizzata tramite un servizio online, perciò l\'importazione può richiedere molto più tempo del normale.').'
+        </div>' : '').'
     </div>
 </div>';
 

--- a/src/Importer/CSVImporter.php
+++ b/src/Importer/CSVImporter.php
@@ -21,6 +21,7 @@
 namespace Importer;
 
 use League\Csv\Reader;
+use League\Csv\Statement;
 
 /**
  * Classe dedicata alla gestione dell'importazione da file CSV.
@@ -96,17 +97,24 @@ abstract class CSVImporter implements ImporterInterface
         return array_shift($first_row);
     }
 
+    /**
+     * Numero totale di record presenti nel file CSV (intestazione inclusa).
+     * Usato dalla UI per calcolare la percentuale di avanzamento dell'importazione.
+     */
+    public function getTotalRows()
+    {
+        return count($this->csv);
+    }
+
     public function getRows($offset, $length)
     {
         $rows = [];
-        for ($i = 0; $i < $length; ++$i) {
-            // Lettura di una singola riga alla volta
-            $row = $this->csv->fetchOne($offset + $i);
-            if (empty($row)) {
-                break;
-            }
 
-            // Aggiunta all'insieme dei record
+        // Lettura del blocco in un'unica passata sequenziale.
+        // NB: chiamare fetchOne($offset + $i) in un ciclo è O(n²), perché league/csv
+        // ri-scorre il file dall'inizio ad ogni chiamata; Statement lo scorre una sola volta.
+        $statement = Statement::create()->offset((int) $offset)->limit((int) $length);
+        foreach ($statement->process($this->csv) as $row) {
             $rows[] = \Filter::parse($row);
         }
 
@@ -170,8 +178,10 @@ abstract class CSVImporter implements ImporterInterface
             $validated_records[] = $record;
         }
 
-        $batch_size = 100;
         $import_failed = 0;
+
+        // Autocommit per riga (volutamente NON in un'unica transazione per batch): così i lock
+        // restano brevissimi e un import lento/abbandonato non blocca l'intera applicazione.
         foreach ($validated_records as $index => $record) {
             $row = $validated_rows[$index];
 


### PR DESCRIPTION
## Descrizione

Migliora performance, robustezza e UX dell'importazione CSV (`modules/import`), in particolare per file grandi (migliaia di righe).

**1. Lettura del batch in un'unica passata — fix O(n²)**
`CSVImporter::getRows()` leggeva ogni riga con `$this->csv->fetchOne($offset + $i)` in un ciclo. `league/csv::fetchOne()` ri-scorre il file dall'inizio ad **ogni** chiamata, quindi l'importazione era **quadratica** (~12,5 milioni di parse di riga per 5000 righe, con rallentamento progressivo verso la fine). Ora il batch viene letto una sola volta con `Statement::create()->offset()->limit()`.

**Risultato misurato:** testato su un'importazione reale di **5000+ anagrafiche clienti e oltre 30 000 articoli di magazzino**, l'avanzamento che prima richiedeva diversi minuti (o nel nostro caso ore per gli articoli di magazzino) ora si completa in **pochi secondi/minuti**.

**2. Dimensione del batch 500 → 100**
Richieste più brevi (meno rischio di timeout del proxy / PHP su file grandi) e aggiornamenti di avanzamento più frequenti.

**3. Progress bar + messaggi di errore leggibili (`modules/import/edit.php`)**
- Lo spinner a tutto schermo è sostituito da un overlay con **progress bar** che si aggiorna dopo ogni batch (righe processate / totale + percentuale). Il totale arriva dal nuovo `CSVImporter::getTotalRows()`.
- In caso di errore della richiesta, il callback `error` di `ajaxSubmit` concatenava l'oggetto `jqXHR` in una stringa, mostrando `[object Object]`. Ora viene mostrato il messaggio reale (`responseJSON.message` → `responseText` → `statusText`).

**4. Avvisi all'utente nell'overlay di avanzamento**
- Avviso a non chiudere/ricaricare la pagina finché l'importazione non è completata.
- Avviso **dinamico** (solo per import anagrafiche con "Geolocalizzazione automatica" attiva) che segnala tempi più lunghi, dato che ogni riga viene geolocalizzata tramite un servizio online.

<img width="1863" height="822" alt="Screenshot 2026-06-08 alle 12 11 20" src="https://github.com/user-attachments/assets/437e24e9-8528-4aaa-b786-d4da62066ae0" />

<img width="1870" height="824" alt="Screenshot 2026-06-08 alle 13 08 29" src="https://github.com/user-attachments/assets/a59e7f1c-79b1-4225-90ef-c7965b66e724" />



Nessuna nuova dipendenza richiesta. Nessuna modifica allo schema.

Risolve: [ISSUE 1459](https://github.com/devcode-it/openstamanager/issues/1459)

## Tipologia

- [x] Bug fix (cambiamenti minori che risolvono una issue)
- [x] Nuova funzionalità (cambiamenti minori che aggiungono una nuova funzionalità)

# Checklist

- [x] Il codice segue le linee guida del progetto
- [x] Ho commentato il codice, in particolare nelle parti più complesse
- [ ] Ho aggiornato di conseguenza la documentazione (se presente)
- [x] Il codice non genera warnings

---

### Nota sul check Codacy (da ignorare)

Codacy segnala su alcune righe *"All output should be run through an escaping function … found 'tr'"* (es. `modules/import/edit.php`, la riga con `tr('Importazione in corso...')`).

È un **falso positivo**: la regola proviene dai *WordPress Coding Standards* (`WordPress.Security.EscapeOutput`), che pretende `esc_html()`/`esc_attr()` e non riconosce `tr()` come funzione di escaping. OSM **non** è WordPress e usa `tr()` come funzione standard di traduzione/output in tutto il progetto (centinaia di occorrenze). Le righe introdotte qui seguono **esattamente la stessa convenzione** già presente nello stesso file (es. le righe pre-esistenti con `tr('Informazioni importanti:')`, `tr('Campi obbligatori (*):')`, ecc.). Inoltre gli argomenti di `tr()` sono **stringhe statiche**, non input utente.

La segnalazione può quindi essere **ignorata**.
