### PR TITLE
fix(ddt): colonna errata 'v' nella ricerca fattura da accodare generando fattura da DDT

### DIFF
--- a/modules/ddt/bulk.php
+++ b/modules/ddt/bulk.php
@@ -92,7 +92,7 @@ switch (post('op')) {
                                 ->where('id_sede_destinazione', $id_sede)
                                 ->first();
                         } else {
-                            $fattura = Fattura::where('v', $id_anagrafica)
+                            $fattura = Fattura::where('id_anagrafica', $id_anagrafica)
                                 ->where('id_stato', $stato_documenti_accodabili->id)
                                 ->where('id_tipo_documento', $tipo_documento->id)
                                 ->first();


### PR DESCRIPTION
## Descrizione

Trasformando dei DDT in fatture si verifica il seguente errore SQL:

```
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'v' in 'WHERE' (Connection: default, Host: mariadb, Port: , Database: osm, SQL: select * from `co_documenti` where `v` = 3807 and `id_stato` = 2 and `id_tipo_documento` = 46 limit 1)
```

La causa è in `modules/ddt/bulk.php`: nella ricerca della fattura su cui registrare le righe del DDT viene usato il nome colonna errato `'v'` invece di `'id_anagrafica'`. La modifica corregge il nome della colonna:

```diff
-  $fattura = Fattura::where('v', $id_anagrafica)
+  $fattura = Fattura::where('id_anagrafica', $id_anagrafica)
```

Una sola riga, nessuna dipendenza aggiuntiva, nessun'altra occorrenza del refuso nel codice.

Risolve: nessuna issue collegata (bug riscontrato in uso).

## Tipologia

- [x] Bug fix (cambiamenti minori che risolvono una issue)

# Checklist

- [x] Il codice segue le linee guida del progetto
- [ ] Ho commentato il codice, in particolare nelle parti più complesse (n/a — modifica di una sola riga)
- [ ] Ho aggiornato di conseguenza la documentazione (se presente) — non necessario
- [x] Il codice non genera warnings