### PR TITLE
Add PHP client for API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,5 @@ codeception.yml
 openapi.json
 assets/api
 openapitools.json
+src/generated
+src/OpenAPI

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,1 +1,8 @@
+approvedGitRepositories:
+  - "**"
+
+enableScripts: true
+
 nodeLinker: node-modules
+
+npmMinimalAgeGate: 0

--- a/package.json
+++ b/package.json
@@ -103,9 +103,12 @@
         "rector": "vendor/bin/rector process",
         "setup-corepack": "npm install -g corepack && corepack enable",
         "export-openapi": "php artisan api:openapi:export --output=openapi.json",
+        "update-openapi-client": "npm run copy-vendor-css-folder && npm run-script export-openapi && npm run update-openapi-client-js && npm run update-openapi-client-php",
         "fix-openapi-js": "node -e \"require('fs').writeFileSync('assets/api/src/main.js', \\\"import * as API from './index';global.window.API = API;\\\");\"",
-        "copy-vendor-css-folder": "node -e \"const fs = require('fs'); const sourceFolder = './vendor/api-platform/laravel/public'; const destFolder = './assets/dist/apiplatform'; const copyFolder = (src, dest) => { if (!fs.existsSync(dest)) fs.mkdirSync(dest); fs.readdirSync(src).forEach(file => { const srcFile = path.join(src, file); const destFile = path.join(dest, file); if (fs.statSync(srcFile).isDirectory()) copyFolder(srcFile, destFile); else fs.copyFileSync(srcFile, destFile); }); }; copyFolder(sourceFolder, destFolder);\"",
-        "update-openapi-client": "npm run copy-vendor-css-folder && npm run-script export-openapi && npx @openapitools/openapi-generator-cli generate -i openapi.json -g javascript -o assets/api --skip-validate-spec && npm run-script fix-openapi-js && cd ./assets/api && npm install && npx babel src -d dist && cd ../.. && npx browserify -y ./assets/api/dist/main.js -o ./assets/dist/js/api.js"
+        "copy-folder": "node -e \"const fs = require('fs'), p = require('path'); const sourceFolder = p.resolve(process.env.SRC); const destFolder = p.resolve(process.env.DEST); const copyFolder = (src, dest) => { if (!fs.existsSync(dest)) fs.mkdirSync(dest, { recursive: true }); fs.readdirSync(src).forEach(file => { const srcFile = p.join(src, file); const destFile = p.join(dest, file); if (fs.statSync(srcFile).isDirectory()) copyFolder(srcFile, destFile); else fs.copyFileSync(srcFile, destFile); }); }; copyFolder(sourceFolder, destFolder);\"",
+        "copy-vendor-css-folder": "SRC=./vendor/api-platform/laravel/public DEST=./assets/dist/apiplatform npm run copy-folder",
+        "update-openapi-client-js": "npx @openapitools/openapi-generator-cli generate -i openapi.json -g javascript -o assets/api --skip-validate-spec && npm run-script fix-openapi-js && cd ./assets/api && npm install && npx babel src -d dist && cd ../.. && npx browserify -y ./assets/api/dist/main.js -o ./assets/dist/js/api.js",
+        "update-openapi-client-php": "npx @openapitools/openapi-generator-cli generate -i openapi.json -g php -o src/generated --skip-validate-spec && SRC=./src/generated/lib DEST=./src/OpenAPI/Client npm run copy-folder && rm -rf src/generated"
     },
-    "packageManager": "yarn@4.12.0"
+    "packageManager": "yarn@4.17.1"
 }


### PR DESCRIPTION
Aggiunta di autogenerazione del client per API in PHP per utilizzo da componenti standard del gestionale.

Alla lunga, idealmente spostiamo la gestione di init.php dei moduli a una chiamata API del genere, che può avvenire via PHP o JS e restituisce i dati legati al record rilevante.

Include aggiornamento di Yarn.