### PR TITLE
Migliora lo storico SMS e WhatsApp nei documenti

### DIFF
--- a/src/HTMLBuilder/Manager/SMSManager.php
+++ b/src/HTMLBuilder/Manager/SMSManager.php
@@ -24,7 +24,7 @@ use Models\Module;
 use Modules\SMS\Sms;
 
 /**
- * Gestione SMS.
+ * Gestione SMS e WhatsApp.
  *
  * @since 2.4.2
  */
@@ -46,7 +46,7 @@ class SMSManager implements ManagerInterface
             return ' ';
         }
 
-        // Visualizzo il log delle operazioni di invio SMS
+        // Visualizzo il log delle comunicazioni SMS e WhatsApp
         $messages = Sms::whereRaw('id_template IN (SELECT id FROM sms_templates WHERE id_module = '.prepare($options['id_module']).')')
             ->where('id_record', $options['id_record'])
             ->orderBy('created_at', 'DESC')
@@ -57,38 +57,42 @@ class SMSManager implements ManagerInterface
         }
 
         // Codice HTML
-        $result = '
-<div class="card card-info collapsable collapsed-card">
-    <div class="card-header with-border">
-        <h3 class="card-title"><i class="fa fa-comment"></i> '.tr('SMS inviati: _NUM_', [
+        $result = '\n<div class="card card-info collapsable collapsed-card">\n    <div class="card-header with-border">\n        <h3 class="card-title"><i class="fa fa-comment"></i> '.tr('SMS e WhatsApp: _NUM_', [
             '_NUM_' => $messages->count(),
-        ]).'</h3>
-        <div class="card-tools pull-right">
-            <button type="button" class="btn btn-card-tool" data-card-widget="collapse"><i class="fa fa-plus"></i></button>
-        </div>
-    </div>
-    <div class="card-body">
-        <ul>';
+        ]).'</h3>\n        <div class="card-tools pull-right">\n            <button type="button" class="btn btn-card-tool" data-card-widget="collapse"><i class="fa fa-plus"></i></button>\n        </div>\n    </div>\n    <div class="card-body">\n        <ul>';
 
         foreach ($messages as $message) {
-            $sent = !empty($message['sent_at']) ? tr('inviato il _DATE_ alle _HOUR_', [
-                '_DATE_' => dateFormat($message['sent_at']),
-                '_HOUR_' => timeFormat($message['sent_at']),
-            ]) : tr('in coda di invio');
+            $message_type = $message->message_type ?: 'sms';
+            $is_whatsapp = in_array($message_type, ['whatsapp', 'whatsapp_link']);
+            $channel = $is_whatsapp ? tr('WhatsApp') : tr('SMS');
+            $icon = $is_whatsapp ? 'fa-whatsapp' : 'fa-comment';
 
-            $descrizione = \Modules::link('Coda SMS', $message->id, tr('SMS "_TEMPLATE_" da _USER_', [
+            if ($message_type === 'whatsapp_link') {
+                $status = !empty($message['sent_at']) ? tr('aperto il _DATE_ alle _HOUR_', [
+                    '_DATE_' => dateFormat($message['sent_at']),
+                    '_HOUR_' => timeFormat($message['sent_at']),
+                ]) : tr('apertura non completata');
+            } elseif (!empty($message['sent_at'])) {
+                $status = tr('inviato il _DATE_ alle _HOUR_', [
+                    '_DATE_' => dateFormat($message['sent_at']),
+                    '_HOUR_' => timeFormat($message['sent_at']),
+                ]);
+            } elseif (!empty($message['failed_at'])) {
+                $status = tr('invio non riuscito');
+            } else {
+                $status = tr('in coda di invio');
+            }
+
+            $description = \Modules::link('Coda SMS', $message->id, tr('_CHANNEL_ "_TEMPLATE_" da _USER_', [
+                '_CHANNEL_' => $channel,
                 '_TEMPLATE_' => $message->template ? $message->template->name : tr('Template eliminato'),
                 '_USER_' => $message->user ? $message->user->username : tr('Utente eliminato'),
             ]));
 
-            $result .= '
-            <li>'.$descrizione.' ('.$sent.')</li>';
+            $result .= '\n            <li>\n                <i class="fa '.$icon.'"></i> '.$description.' ('.$status.').\n                <ul>\n                    <li><b>'.tr('Destinatario').'</b>: '.htmlspecialchars((string) $message->cellulare, ENT_QUOTES, 'UTF-8').'.</li>\n                </ul>\n            </li>';
         }
 
-        $result .= '
-        </ul>
-    </div>
-</div>';
+        $result .= '\n        </ul>\n    </div>\n</div>';
 
         return $result;
     }


### PR DESCRIPTION
## Descrizione

Questa modifica migliora la visualizzazione dello storico dei messaggi nei documenti.

In particolare:

- aggiorna il titolo della sezione in **SMS e WhatsApp**;
- mantiene il contatore delle comunicazioni associate al documento;
- distingue visivamente SMS e WhatsApp mediante le icone dedicate;
- mostra uno stato specifico per i messaggi aperti tramite collegamento WhatsApp;
- evidenzia i messaggi non inviati o ancora in coda;
- aggiunge il numero del destinatario nel dettaglio.

La modifica è limitata alla visualizzazione dello storico e non altera il processo di invio dei messaggi.

Chiude #1878.