### PR TITLE
Aggiunge widget riepilogativi e filtri rapidi allo Scadenzario

### DIFF
--- a/modules/scadenzario/controller_before.php
+++ b/modules/scadenzario/controller_before.php
@@ -1,38 +1,350 @@
 <?php
 
+/*
+ * OpenSTAManager: il software gestionale open source per l'assistenza tecnica e la fatturazione
+ * Copyright (C) DevCode s.r.l.
+ *
+ * Personalizzazione Scadenzario: riepilogo operativo per stato, coerente con
+ * i permessi, il segmento attivo e gli eventuali placeholder temporali.
+ */
+
+use Util\Query;
+
+$escape = static fn ($value): string => htmlspecialchars((string) $value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+
+$remove_outer_order_and_limit = static function ($query): string {
+    $query = (string) $query;
+    $length = strlen($query);
+    $depth = 0;
+    $quote = null;
+    $escape_next = false;
+    $cut_position = null;
+
+    for ($i = 0; $i < $length; ++$i) {
+        $char = $query[$i];
+
+        if ($quote !== null) {
+            if ($escape_next) {
+                $escape_next = false;
+                continue;
+            }
+
+            if ($char === '\\') {
+                $escape_next = true;
+                continue;
+            }
+
+            if ($char === $quote) {
+                if ($i + 1 < $length && $query[$i + 1] === $quote) {
+                    ++$i;
+                    continue;
+                }
+
+                $quote = null;
+            }
+
+            continue;
+        }
+
+        if ($char === "'" || $char === '"' || $char === '`') {
+            $quote = $char;
+            continue;
+        }
+
+        if ($char === '(') {
+            ++$depth;
+            continue;
+        }
+
+        if ($char === ')') {
+            $depth = max(0, $depth - 1);
+            continue;
+        }
+
+        if ($depth !== 0) {
+            continue;
+        }
+
+        $remaining = substr($query, $i);
+        if (preg_match('/^\s*(?:ORDER\s+BY|LIMIT)\b/i', $remaining)) {
+            $cut_position = $i;
+            break;
+        }
+    }
+
+    if ($cut_position !== null) {
+        $query = substr($query, 0, $cut_position);
+    }
+
+    return rtrim(trim($query), ';');
+};
+
+$states = [
+    'paid' => [
+        'title' => tr('Scadenze pagate'),
+        'short_title' => tr('Pagate'),
+        'color' => '#CCFFCC',
+        'icon' => 'fa fa-check-circle',
+        'amount_label' => tr('saldati'),
+    ],
+    'agreed_overdue' => [
+        'title' => tr('Data concordata superata'),
+        'short_title' => tr('Concordata superata'),
+        'color' => '#ec5353',
+        'icon' => 'fa fa-exclamation-circle',
+        'amount_label' => tr('residui'),
+    ],
+    'agreed' => [
+        'title' => tr('Data concordata'),
+        'short_title' => tr('Concordata'),
+        'color' => '#b3d2e3',
+        'icon' => 'fa fa-calendar-check-o',
+        'amount_label' => tr('residui'),
+    ],
+    'overdue' => [
+        'title' => tr('Scaduta'),
+        'short_title' => tr('Scadute'),
+        'color' => '#f08080',
+        'icon' => 'fa fa-calendar-times-o',
+        'amount_label' => tr('residui'),
+    ],
+    'due_soon' => [
+        'title' => tr('Scadenza entro 10 giorni'),
+        'short_title' => tr('Entro 10 giorni'),
+        'color' => '#f9f9c6',
+        'icon' => 'fa fa-clock-o',
+        'amount_label' => tr('residui'),
+    ],
+    'future' => [
+        'title' => tr('Scadenza futura'),
+        'short_title' => tr('Future'),
+        'color' => '#ffffff',
+        'icon' => 'fa fa-calendar-o',
+        'amount_label' => tr('residui'),
+    ],
+];
+
+$summary = array_fill_keys(array_keys($states), [
+    'count' => 0,
+    'amount' => 0.0,
+]);
+
+$id_segment = $_SESSION['module_'.$id_module]['id_segment'] ?? null;
+$segment_title = tr('Tutte le scadenze');
+
+if (!empty($id_segment)) {
+    $segment = $dbo->fetchOne('SELECT COALESCE(NULLIF(`zz_segments_lang`.`title`, \'\'), `zz_segments`.`name`) AS `title`
+        FROM `zz_segments`
+        LEFT JOIN `zz_segments_lang` ON (`zz_segments`.`id` = `zz_segments_lang`.`id_record` AND `zz_segments_lang`.`id_lang` = '.prepare(Models\Locale::getDefault()->id).')
+        WHERE `zz_segments`.`id` = '.prepare($id_segment).' AND `zz_segments`.`id_module` = '.prepare($id_module));
+
+    if (!empty($segment['title'])) {
+        $segment_title = $segment['title'];
+    }
+}
+
+$segment_title = html_entity_decode((string) $segment_title, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+$segment_title = strip_tags($segment_title);
+$segment_title = trim((string) preg_replace('/\s+/', ' ', $segment_title));
+
+$current_user = auth_osm()->getUser();
+$current_user_id = (int) (is_array($current_user)
+    ? ($current_user['id'] ?? 0)
+    : ($current_user->id ?? 0));
+
+$state_view = $dbo->fetchOne("SELECT COALESCE(NULLIF(`zz_views_lang`.`title`, ''), `zz_views`.`name`) AS `title`
+    FROM `zz_views`
+    INNER JOIN `zz_group_view` ON `zz_group_view`.`id_vista` = `zz_views`.`id`
+    INNER JOIN `zz_users` ON `zz_users`.`idgruppo` = `zz_group_view`.`id_gruppo`
+    LEFT JOIN `zz_views_lang` ON (`zz_views`.`id` = `zz_views_lang`.`id_record` AND `zz_views_lang`.`id_lang` = ".prepare(Models\Locale::getDefault()->id).")
+    WHERE `zz_views`.`id_module` = ".prepare($id_module)."
+        AND `zz_views`.`name` = ".prepare('Stato scadenza')."
+        AND `zz_users`.`id` = ".prepare($current_user_id)."
+    LIMIT 1");
+
+$state_field = $state_view['title'] ?? 'Stato scadenza';
+$state_header_id = 'th_'.searchFieldName($state_field);
+$filter_available = !empty($state_view);
+$summary_error = false;
+
+unset($_SESSION['module_'.$id_module]['_search_'.searchFieldName($state_field)]);
+
+$summary_cache_ttl = 30;
+$summary_cache_key = hash('sha256', implode('|', [
+    (string) $id_module,
+    (string) $current_user_id,
+    (string) $id_segment,
+    (string) ($_SESSION['period_start'] ?? ''),
+    (string) ($_SESSION['period_end'] ?? ''),
+]));
+$summary_cache = $_SESSION['osm_scadenzario_widget_cache'][$summary_cache_key] ?? null;
+
+if (
+    is_array($summary_cache)
+    && isset($summary_cache['created_at'], $summary_cache['summary'])
+    && (time() - (int) $summary_cache['created_at']) <= $summary_cache_ttl
+    && is_array($summary_cache['summary'])
+) {
+    foreach ($summary_cache['summary'] as $state => $values) {
+        if (isset($summary[$state]) && is_array($values)) {
+            $summary[$state]['count'] = (int) ($values['count'] ?? 0);
+            $summary[$state]['amount'] = (float) ($values['amount'] ?? 0);
+        }
+    }
+} else {
+    try {
+        $state_expression = "IF(pagato=da_pagare,'paid',IF(data_concordata<>'0000-00-00',IF(data_concordata<NOW(),'agreed_overdue','agreed'),IF(scadenza<NOW(),'overdue',IF(DATEDIFF(scadenza,NOW())<10,'due_soon','future'))))";
+
+        $technical_select = [
+            '`co_scadenziario`.`id` AS `osm_scadenza_id`',
+            $state_expression.' AS `osm_scadenza_stato`',
+            'ABS(`co_scadenziario`.`da_pagare` - `co_scadenziario`.`pagato`) AS `osm_scadenza_residuo`',
+            'ABS(`co_scadenziario`.`da_pagare`) AS `osm_scadenza_importo`',
+        ];
+
+        $having_additionals = Modules::getAdditionalsQuery($id_module, 'HVN');
+
+        if (!empty($having_additionals)) {
+            $module_query = Query::readQuery($structure);
+            $detail_query = $module_query['query'] ?? '';
+            $replacements = 0;
+            $detail_query = preg_replace(
+                '/^\s*SELECT\s+/i',
+                'SELECT '.implode(', ', $technical_select).', ',
+                (string) $detail_query,
+                1,
+                $replacements
+            );
+
+            if ($replacements !== 1) {
+                throw new RuntimeException('SELECT modulare dello Scadenzario non riconosciuta.');
+            }
+        } else {
+            $module = $dbo->fetchOne('SELECT `options`, `options2` FROM `zz_modules` WHERE `id` = '.prepare($id_module));
+            $base_query = !empty($module['options2']) ? $module['options2'] : ($module['options'] ?? '');
+
+            if (empty($base_query) || !str_contains($base_query, '|select|')) {
+                throw new RuntimeException('Query modulare dello Scadenzario non compatibile con il riepilogo.');
+            }
+
+            $detail_query = str_replace('|select|', implode(', ', $technical_select), $base_query);
+        }
+
+        $detail_query = Modules::replaceAdditionals($id_module, $detail_query);
+        $detail_query = Query::replacePlaceholder($detail_query);
+        $detail_query = $remove_outer_order_and_limit($detail_query);
+
+        $summary_query = 'SELECT
+                `osm_scadenza_stato` AS `state`,
+                COUNT(*) AS `count`,
+                SUM(`osm_scadenza_valore`) AS `amount`
+            FROM (
+                SELECT
+                    `osm_scadenza_id`,
+                    MAX(`osm_scadenza_stato`) AS `osm_scadenza_stato`,
+                    MAX(IF(`osm_scadenza_stato` = \'paid\', `osm_scadenza_importo`, `osm_scadenza_residuo`)) AS `osm_scadenza_valore`
+                FROM ('.$detail_query.') AS `osm_scadenzario_widget_source`
+                GROUP BY `osm_scadenza_id`
+            ) AS `osm_scadenzario_widget_rows`
+            GROUP BY `osm_scadenza_stato`';
+
+        $rows = $dbo->fetchArray($summary_query);
+        foreach ($rows as $row) {
+            $state = $row['state'] ?? '';
+            if (isset($summary[$state])) {
+                $summary[$state]['count'] = (int) ($row['count'] ?? 0);
+                $summary[$state]['amount'] = (float) ($row['amount'] ?? 0);
+            }
+        }
+
+        $_SESSION['osm_scadenzario_widget_cache'][$summary_cache_key] = [
+            'created_at' => time(),
+            'summary' => $summary,
+        ];
+    } catch (Throwable $e) {
+        $summary_error = true;
+        error_log('[Scadenzario widget] '.$e->getMessage());
+    }
+}
+
+$js_path = $structure->filepath('js/scadenzario-widgets.js');
+$css_path = $structure->filepath('css/scadenzario-widgets.css');
+$js_url = $structure->fileurl('js/scadenzario-widgets.js');
+$css_url = $structure->fileurl('css/scadenzario-widgets.css');
+
+$asset_version = (string) max(
+    $js_path && is_file($js_path) ? (int) filemtime($js_path) : 0,
+    $css_path && is_file($css_path) ? (int) filemtime($css_path) : 0
+);
+
 echo '
-<div class="container">
-    <div class="row">
-        <div class=col-md-12">
-            <h5>'.tr('Legenda').':</h5>
+<link rel="stylesheet" href="'.$escape($css_url).'?v='.$asset_version.'">
+
+<section class="osm-scadenzario-summary" id="osm-scadenzario-summary"
+    data-module-id="'.$escape($id_module).'"
+    data-state-header-id="'.$escape($state_header_id).'"
+    data-state-field="'.$escape($state_field).'"
+    data-filter-enabled="'.($filter_available ? '1' : '0').'"
+    data-state-column-index=""
+    data-active-state="">
+    <div class="osm-scadenzario-summary-header">
+        <div>
+            <h4><i class="fa fa-line-chart"></i> '.tr('Riepilogo scadenze').'</h4>
+            <div class="osm-scadenzario-segment">
+                '.tr('Segmento attivo').': <strong>'.$escape($segment_title).'</strong>
+            </div>
         </div>
-    </div>
-    <div class="row">
-        <div class="col-md-4">
-            <span class="pull-left icon" style="background-color:#CCFFCC;"></span>
-            <span class="text">&nbsp;'.tr('Scadenza pagata').'</span>
-        </div>
-        <div class="col-md-4">
-            <span class="pull-left icon" style="background-color:#ec5353;"></span>
-            <span class="text">&nbsp;'.tr('Data concordata superata').'</span>
-        </div>
-        <div class="col-md-4">
-            <span class="pull-left icon" style="background-color:#b3d2e3;"></span>
-            <span class="text">&nbsp;'.tr('Data concordata').'</span>
-        </div>
-    </div>
-    <div class="row">
-        <div class="col-md-4">
-            <span class="pull-left icon" style="background-color:#f08080;"></span>
-            <span class="text">&nbsp;'.tr('Scaduta').'</span>
-        </div>
-        <div class="col-md-4">
-            <span class="pull-left icon" style="background-color:#f9f9c6;"></span>
-            <span class="text">&nbsp;'.tr('Scadenza entro 10 giorni').'</span>
-        </div>
-        <div class="col-md-4">
-            <span class="pull-left icon" style="background-color:#ffffff;"></span>
-            <span class="text">&nbsp;Scadenza futura</span>
-        </div>
-    </div>
-</div>';
+        <button type="button" class="btn btn-default btn-sm osm-scadenzario-reset-filter hide">
+            <i class="fa fa-times"></i> '.tr('Mostra tutte').'
+        </button>
+    </div>';
+
+if ($summary_error) {
+    echo '
+    <div class="alert alert-warning osm-scadenzario-summary-error">
+        <i class="fa fa-exclamation-triangle"></i>
+        '.tr('Riepilogo temporaneamente non disponibile. La tabella dello Scadenzario rimane utilizzabile.').'
+    </div>';
+} else {
+    if (!$filter_available) {
+        echo '
+    <div class="alert alert-info osm-scadenzario-summary-error">
+        <i class="fa fa-info-circle"></i>
+        '.tr('La vista tecnica necessaria ai filtri non è disponibile per il gruppo utente corrente. Completare l’aggiornamento dello Scadenzario.').'
+    </div>';
+    }
+
+    echo '
+    <div class="row osm-scadenzario-widget-row">';
+
+    foreach ($states as $key => $state) {
+        $count = $summary[$key]['count'];
+        $amount = Translator::numberToLocale($summary[$key]['amount'], 2);
+        $disabled = (!$filter_available || $count === 0) ? ' disabled aria-disabled="true"' : '';
+
+        echo '
+        <div class="col-xl-2 col-lg-4 col-md-6 col-sm-6 col-12">
+            <button type="button"
+                class="osm-scadenzario-widget"
+                data-state="'.$escape($key).'"
+                title="'.$escape($state['title']).'"
+                aria-pressed="false"
+                style="--osm-widget-color: '.$escape($state['color']).';"'.$disabled.'>
+                <span class="osm-scadenzario-widget-icon"><i class="'.$escape($state['icon']).'"></i></span>
+                <span class="osm-scadenzario-widget-content">
+                    <span class="osm-scadenzario-widget-title">'.$escape($state['short_title']).'</span>
+                    <span class="osm-scadenzario-widget-count">'.$count.' '.($count === 1 ? tr('scadenza') : tr('scadenze')).'</span>
+                    <span class="osm-scadenzario-widget-amount">&euro; '.$escape($amount).' <small>'.$escape($state['amount_label']).'</small></span>
+                </span>
+            </button>
+        </div>';
+    }
+
+    echo '
+    </div>';
+}
+
+echo '
+</section>
+
+<script src="'.$escape($js_url).'?v='.$asset_version.'"></script>';

--- a/modules/scadenzario/css/scadenzario-widgets.css
+++ b/modules/scadenzario/css/scadenzario-widgets.css
@@ -1,0 +1,151 @@
+.osm-scadenzario-summary {
+    margin: 0 0 18px;
+    padding: 16px 16px 4px;
+    border: 1px solid #dfe3e8;
+    border-radius: 6px;
+    background: #f8f9fa;
+}
+
+.osm-scadenzario-summary-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 12px;
+}
+
+.osm-scadenzario-summary-header h4 {
+    margin: 0 0 3px;
+    font-size: 16px;
+    font-weight: 600;
+}
+
+.osm-scadenzario-segment {
+    color: #6c757d;
+    font-size: 12px;
+}
+
+.osm-scadenzario-widget-row > div {
+    margin-bottom: 12px;
+}
+
+.osm-scadenzario-widget {
+    position: relative;
+    display: flex;
+    align-items: stretch;
+    width: 100%;
+    min-height: 92px;
+    padding: 0;
+    overflow: hidden;
+    text-align: left;
+    border: 1px solid #d8dde3;
+    border-left: 5px solid var(--osm-widget-color);
+    border-radius: 5px;
+    background: #fff;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+    cursor: pointer;
+    transition: box-shadow 0.15s ease, transform 0.15s ease, border-color 0.15s ease;
+}
+
+.osm-scadenzario-widget:hover,
+.osm-scadenzario-widget:focus {
+    transform: translateY(-1px);
+    border-color: #9aa4af;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.10);
+    outline: none;
+}
+
+.osm-scadenzario-widget.active {
+    border-color: #337ab7;
+    box-shadow: 0 0 0 2px rgba(51, 122, 183, 0.22);
+}
+
+.osm-scadenzario-widget:disabled {
+    cursor: default;
+    opacity: 0.75;
+}
+
+.osm-scadenzario-widget:disabled:hover,
+.osm-scadenzario-widget:disabled:focus {
+    transform: none;
+    border-color: #d8dde3;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+}
+
+.osm-scadenzario-widget-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 48px;
+    color: #343a40;
+    background: var(--osm-widget-color);
+    border-right: 1px solid rgba(0, 0, 0, 0.06);
+    font-size: 20px;
+}
+
+.osm-scadenzario-widget-content {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    min-width: 0;
+    padding: 10px 11px;
+}
+
+.osm-scadenzario-widget-title {
+    overflow: hidden;
+    color: #343a40;
+    font-size: 11px;
+    font-weight: 700;
+    line-height: 1.25;
+    text-overflow: ellipsis;
+    text-transform: uppercase;
+    white-space: nowrap;
+}
+
+.osm-scadenzario-widget-count {
+    margin-top: 4px;
+    color: #4f5963;
+    font-size: 12px;
+}
+
+.osm-scadenzario-widget-amount {
+    margin-top: 2px;
+    color: #212529;
+    font-size: 15px;
+    font-weight: 700;
+    line-height: 1.2;
+}
+
+.osm-scadenzario-widget-amount small {
+    color: #77808a;
+    font-size: 10px;
+    font-weight: 400;
+}
+
+.osm-scadenzario-summary-error {
+    margin-bottom: 12px;
+}
+
+.osm-scadenzario-widget[disabled] {
+    filter: grayscale(0.18);
+    opacity: 0.58;
+}
+
+.osm-scadenzario-widget[disabled] .osm-scadenzario-widget-count,
+.osm-scadenzario-widget[disabled] .osm-scadenzario-widget-amount {
+    color: #6c757d;
+}
+
+@media (max-width: 767px) {
+    .osm-scadenzario-summary {
+        padding: 12px 12px 0;
+    }
+
+    .osm-scadenzario-summary-header {
+        align-items: flex-start;
+    }
+
+    .osm-scadenzario-widget {
+        min-height: 84px;
+    }
+}

--- a/modules/scadenzario/js/scadenzario-widgets.js
+++ b/modules/scadenzario/js/scadenzario-widgets.js
@@ -1,0 +1,172 @@
+(function ($) {
+    'use strict';
+
+    var ROOT = '#osm-scadenzario-summary';
+    var STATES = ['paid', 'agreed_overdue', 'agreed', 'overdue', 'due_soon', 'future'];
+
+    function getRoot() {
+        return $(ROOT);
+    }
+
+    function getSettings() {
+        var $root = getRoot();
+        var moduleId = String($root.attr('data-module-id') || '');
+        var settings = ($.fn.dataTable && $.fn.dataTable.settings) || [];
+
+        for (var i = 0; i < settings.length; i += 1) {
+            var current = settings[i];
+            var table = current && current.nTable;
+
+            if (
+                table
+                && String($(table).attr('data-idmodule') || '') === moduleId
+                && !$(table).attr('data-idplugin')
+            ) {
+                return current;
+            }
+        }
+
+        return null;
+    }
+
+    function getStateColumnIndex(settings) {
+        var expectedHeaderId = String(getRoot().attr('data-state-header-id') || '');
+        var columns = (settings && settings.aoColumns) || [];
+
+        for (var i = 0; i < columns.length; i += 1) {
+            var header = columns[i] && columns[i].nTh;
+
+            if (header && String(header.id || '') === expectedHeaderId) {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    function getContext() {
+        var settings = getSettings();
+
+        if (!settings) {
+            return null;
+        }
+
+        var columnIndex = getStateColumnIndex(settings);
+
+        if (columnIndex < 0) {
+            return null;
+        }
+
+        return {
+            settings: settings,
+            api: new $.fn.dataTable.Api(settings),
+            columnIndex: columnIndex
+        };
+    }
+
+    function normalizeState(value) {
+        value = String(value || '');
+        return STATES.indexOf(value) !== -1 ? value : '';
+    }
+
+    function readActiveState(context) {
+        return normalizeState(context.api.column(context.columnIndex).search());
+    }
+
+    function updateInterface(state) {
+        var $root = getRoot();
+        var $widgets = $root.find('.osm-scadenzario-widget');
+
+        state = normalizeState(state);
+
+        $root.attr('data-active-state', state);
+        $widgets.removeClass('active').attr('aria-pressed', 'false');
+        $root.find('.osm-scadenzario-reset-filter').toggleClass('hide', !state);
+
+        if (state) {
+            $widgets
+                .filter('[data-state="' + state + '"]')
+                .addClass('active')
+                .attr('aria-pressed', 'true');
+        }
+    }
+
+    function applyState(requestedState) {
+        var $root = getRoot();
+
+        if ($root.attr('data-filter-enabled') !== '1') {
+            return;
+        }
+
+        var context = getContext();
+
+        if (!context) {
+            console.error('[Scadenzario widget] Tabella o colonna Stato scadenza non trovata.');
+            return;
+        }
+
+        var currentState = readActiveState(context);
+        var nextState = normalizeState(requestedState);
+
+        if (nextState === currentState) {
+            nextState = '';
+        }
+
+        updateInterface(nextState);
+
+        context.api
+            .column(context.columnIndex)
+            .search(nextState)
+            .draw();
+    }
+
+    function hideStateColumn(context) {
+        var column = context.api.column(context.columnIndex);
+
+        if (column.visible()) {
+            column.visible(false, false);
+            context.api.columns.adjust();
+        }
+    }
+
+    function syncInterface() {
+        var context = getContext();
+
+        if (context) {
+            hideStateColumn(context);
+            updateInterface(readActiveState(context));
+            getRoot().attr('data-state-column-index', context.columnIndex);
+        }
+    }
+
+    $(document)
+        .off('.osmScadenzarioFilter')
+        .on(
+            'click.osmScadenzarioFilter',
+            ROOT + ' .osm-scadenzario-widget:not(:disabled)',
+            function (event) {
+                event.preventDefault();
+                event.stopPropagation();
+                applyState($(this).attr('data-state'));
+            }
+        )
+        .on(
+            'click.osmScadenzarioFilter',
+            ROOT + ' .osm-scadenzario-reset-filter',
+            function (event) {
+                event.preventDefault();
+                event.stopPropagation();
+                applyState('');
+            }
+        )
+        .on(
+            'init.dt.osmScadenzarioFilter draw.dt.osmScadenzarioFilter',
+            function () {
+                window.setTimeout(syncInterface, 0);
+            }
+        );
+
+    $(function () {
+        window.setTimeout(syncInterface, 0);
+    });
+}(jQuery));

--- a/update/2_12_1.sql
+++ b/update/2_12_1.sql
@@ -1,0 +1,83 @@
+-- Widget riepilogativi e filtri rapidi per lo Scadenzario
+SET @id_module_scadenzario = (
+    SELECT `id`
+    FROM `zz_modules`
+    WHERE `name` = 'Scadenzario'
+      AND `directory` = 'scadenzario'
+    LIMIT 1
+);
+
+INSERT INTO `zz_views` (
+    `id_module`, `name`, `query`, `order`, `search`, `slow`, `format`,
+    `html_format`, `search_inside`, `order_by`, `visible`, `summable`,
+    `avg`, `default`
+)
+SELECT
+    @id_module_scadenzario,
+    'Stato scadenza',
+    'IF(pagato=da_pagare,''paid'',IF(data_concordata<>''0000-00-00'',IF(data_concordata<NOW(),''agreed_overdue'',''agreed''),IF(scadenza<NOW(),''overdue'',IF(DATEDIFF(scadenza,NOW())<10,''due_soon'',''future''))))',
+    120, 1, 0, 0, 0, '`Stato scadenza`', NULL, 1, 0, 0, 1
+WHERE @id_module_scadenzario IS NOT NULL
+  AND NOT EXISTS (
+      SELECT 1
+      FROM `zz_views`
+      WHERE `id_module` = @id_module_scadenzario
+        AND `name` = 'Stato scadenza'
+  );
+
+UPDATE `zz_views`
+SET
+    `query` = 'IF(pagato=da_pagare,''paid'',IF(data_concordata<>''0000-00-00'',IF(data_concordata<NOW(),''agreed_overdue'',''agreed''),IF(scadenza<NOW(),''overdue'',IF(DATEDIFF(scadenza,NOW())<10,''due_soon'',''future''))))',
+    `order` = 120,
+    `search` = 1,
+    `slow` = 0,
+    `format` = 0,
+    `html_format` = 0,
+    `search_inside` = '`Stato scadenza`',
+    `order_by` = NULL,
+    `visible` = 1,
+    `summable` = 0,
+    `avg` = 0,
+    `default` = 1
+WHERE `id_module` = @id_module_scadenzario
+  AND `name` = 'Stato scadenza';
+
+SET @id_view_stato_scadenza = (
+    SELECT `id`
+    FROM `zz_views`
+    WHERE `id_module` = @id_module_scadenzario
+      AND `name` = 'Stato scadenza'
+    LIMIT 1
+);
+
+INSERT INTO `zz_views_lang` (`id_lang`, `id_record`, `title`)
+SELECT 1, @id_view_stato_scadenza, 'Stato scadenza'
+WHERE @id_view_stato_scadenza IS NOT NULL
+  AND NOT EXISTS (
+      SELECT 1 FROM `zz_views_lang`
+      WHERE `id_lang` = 1 AND `id_record` = @id_view_stato_scadenza
+  );
+
+INSERT INTO `zz_views_lang` (`id_lang`, `id_record`, `title`)
+SELECT 2, @id_view_stato_scadenza, 'Due date status'
+WHERE @id_view_stato_scadenza IS NOT NULL
+  AND NOT EXISTS (
+      SELECT 1 FROM `zz_views_lang`
+      WHERE `id_lang` = 2 AND `id_record` = @id_view_stato_scadenza
+  );
+
+UPDATE `zz_views_lang`
+SET `title` = 'Stato scadenza'
+WHERE `id_lang` = 1 AND `id_record` = @id_view_stato_scadenza;
+
+UPDATE `zz_views_lang`
+SET `title` = 'Due date status'
+WHERE `id_lang` = 2 AND `id_record` = @id_view_stato_scadenza;
+
+INSERT IGNORE INTO `zz_group_view` (`id_gruppo`, `id_vista`)
+SELECT DISTINCT `zz_group_view`.`id_gruppo`, @id_view_stato_scadenza
+FROM `zz_group_view`
+INNER JOIN `zz_views` ON `zz_views`.`id` = `zz_group_view`.`id_vista`
+WHERE `zz_views`.`id_module` = @id_module_scadenzario
+  AND `zz_views`.`id` <> @id_view_stato_scadenza
+  AND @id_view_stato_scadenza IS NOT NULL;


### PR DESCRIPTION
## Motivazione

Sostituisce la legenda statica dello Scadenzario con sei widget operativi, come richiesto nell'issue #1821.

## Modifiche

- aggiunge sei widget per gli stati:
  - pagate;
  - data concordata superata;
  - data concordata;
  - scadute;
  - entro 10 giorni;
  - future;
- mostra per ogni stato il numero di scadenze e il relativo valore economico;
- rispetta il segmento attivo e i permessi del modulo;
- usa una sola query aggregata per il riepilogo;
- applica i filtri tramite la DataTable server-side esistente;
- aggiunge la vista tecnica `Stato scadenza` con `search_inside = `Stato scadenza``;
- mantiene la vista tecnicamente disponibile e nasconde la colonna solo tramite DataTables;
- non modifica le funzioni DataTables globali;
- non introduce polling o endpoint AJAX aggiuntivi.

## Prestazioni

- una sola query riepilogativa all'apertura;
- nessuna query dedicata per ciascun widget;
- nessuna richiesta aggiuntiva al clic oltre alla normale richiesta DataTables;
- cache del riepilogo per utente, segmento e periodo.

## Test eseguiti

- installazione diretta come aggiornamento su OpenSTAManager 2.10.4 pulito;
- apertura Scadenzario senza errori;
- conteggi e importi dei sei widget;
- filtro di tutti i sei stati;
- secondo clic e pulsante “Mostra tutte”;
- cambio segmento;
- colonna tecnica nascosta nell'interfaccia;
- ordinamento e ricerca DataTables;
- test con gruppi Amministratori, Amministrazione e Commercialista;
- PHP lint e controllo sintattico JavaScript;
- MySQL 8.4.5.

Closes #1821