### PR TITLE
fix: utilizza il logo configurato come favicon

### DIFF
--- a/include/top.php
+++ b/include/top.php
@@ -30,6 +30,7 @@ $user = auth_osm()->getUser();
 
 $menu_logo_completo = App::getPaths()['img'].'/logo_completo.png';
 $menu_logo_piccolo = App::getPaths()['img'].'/logo.png';
+$favicon = $paths['img'].'/favicon.png';
 
 $menu_logo_esteso_setting = setting('Logo menu');
 if (!empty($menu_logo_esteso_setting)) {
@@ -52,6 +53,7 @@ if (!empty($menu_logo_compatto_setting)) {
     }
     if (!empty($menu_logo_compatto_file)) {
         $menu_logo_piccolo = base_path_osm().'/files/impostazioni/'.$menu_logo_compatto_file->filename;
+        $favicon = $menu_logo_piccolo;
     }
 }
 
@@ -86,7 +88,7 @@ echo '<!DOCTYPE html>
         <meta name="description" content="'.tr('OpenSTAManager, il software gestionale open source per assistenza tecnica e fatturazione elettronica.').'">
         <meta name="author" content="DevCode s.r.l.">
 
-		<link href="'.$paths['img'].'/favicon.png" rel="icon" type="image/x-icon" />';
+		<link href="'.$favicon.'" rel="icon" />';
 
 if (file_exists(base_dir().'/manifest.json')) {
     echo '


### PR DESCRIPTION
## Descrizione

L'impostazione `Logo menu quadrato / favicon` viene già caricata e utilizzata per il logo compatto del menu, ma il tag `<link rel="icon">` continua a puntare sempre al favicon statico predefinito.

Questa modifica:
- mantiene `assets/dist/img/favicon.png` come fallback;
- usa il file configurato in `Logo menu quadrato / favicon` anche come favicon del browser;
- rimuove il MIME type `image/x-icon` forzato, perché il file configurabile è gestito come media e può non essere un ICO.

## Compatibilità

Nessun cambiamento per le installazioni che non configurano un favicon personalizzato.

La modifica è volutamente limitata a `include/top.php` e non interviene sulla gestione di `ROOTDIR`, `BASEURL`, manifest o routing.

## Verifiche

- diff limitato a un solo file;
- fallback invariato quando l'impostazione è vuota;
- stesso file utilizzato per logo menu compatto e favicon quando configurato.

Correlato alla discussione #1642, senza modificare la logica dei percorsi applicativi.