### PR TITLE
feat: aggiungi arrotondamento totale nei documenti di vendita

### DIFF
--- a/include/document-rounding.php
+++ b/include/document-rounding.php
@@ -1,0 +1,244 @@
+<?php
+
+include_once __DIR__.'/../core.php';
+
+use Common\DocumentRounding;
+use Models\Module;
+use Modules\Contratti\Contratto;
+use Modules\Fatture\Fattura;
+use Modules\Fatture\Stato as StatoFattura;
+use Modules\Iva\Aliquota;
+use Modules\Preventivi\Preventivo;
+
+Permissions::check('rw');
+
+$id_module = (int) get('id_module');
+$id_record = (int) get('id_record');
+$module = Module::find($id_module);
+$defaultMode = DocumentRounding::defaultMode();
+
+if (!$module || !$id_record || $defaultMode === null) {
+    echo '<div class="alert alert-info"><i class="fa fa-info-circle"></i> '.tr('Arrotondamento non disponibile.').'</div>';
+    return;
+}
+
+$document = null;
+$isInvoice = false;
+$blockedReasons = [];
+$vatLocked = false;
+$accountId = null;
+
+switch ((string) $module->directory) {
+    case 'preventivi':
+        $document = Preventivo::find($id_record);
+        if (!$document || !empty($document->stato->is_bloccato)) {
+            echo '<div class="alert alert-warning"><i class="fa fa-lock"></i> '.tr('Preventivo non modificabile.').'</div>';
+            return;
+        }
+        if (DocumentRounding::hasSections($document)) {
+            $blockedReasons[] = 'sectioned_quote';
+        }
+        break;
+
+    case 'contratti':
+        $document = Contratto::find($id_record);
+        if (!$document || !empty($document->stato->is_bloccato)) {
+            echo '<div class="alert alert-warning"><i class="fa fa-lock"></i> '.tr('Contratto non modificabile.').'</div>';
+            return;
+        }
+        break;
+
+    case 'fatture':
+        if ($module->name !== 'Fatture di vendita') {
+            break;
+        }
+        $document = Fattura::find($id_record);
+        $draftId = (int) StatoFattura::where('name', 'Bozza')->value('id');
+        if (!$document || $document->direzione !== 'entrata' || (int) $document->id_stato !== $draftId) {
+            echo '<div class="alert alert-warning"><i class="fa fa-lock"></i> '.tr('Disponibile solo sulle fatture di vendita in Bozza.').'</div>';
+            return;
+        }
+        $isInvoice = true;
+        $blockedReasons = array_merge($blockedReasons, DocumentRounding::invoiceGuard($document));
+        $vatLocked = !empty($document->id_dichiarazione_intento);
+        break;
+}
+
+if (!$document) {
+    echo '<div class="alert alert-warning"><i class="fa fa-info-circle"></i> '.tr('Arrotondamento non disponibile per questo documento.').'</div>';
+    return;
+}
+
+$dir = (string) $document->direzione;
+$fallbackVat = $vatLocked
+    ? (int) setting("Iva per lettere d'intento")
+    : (int) ($document->anagrafica?->id_iva_vendite ?: setting('Iva predefinita'));
+$context = DocumentRounding::context($document, $fallbackVat ?: null);
+$existing = $context['existing'];
+
+if ($context['duplicate_count'] > 1) {
+    $blockedReasons[] = 'duplicate_rounding';
+}
+
+$selectedVatId = $vatLocked ? $fallbackVat : (int) ($context['default_vat_id'] ?: 0);
+if ($isInvoice) {
+    $accountId = $existing && !empty($existing->id_conto)
+        ? (int) $existing->id_conto
+        : (int) setting('Conto predefinito fatture di vendita');
+    if (!$accountId) {
+        $blockedReasons[] = 'missing_account';
+    }
+}
+
+$vatIds = array_values(array_unique(array_filter(array_map('intval', $context['vat_ids']))));
+if ($selectedVatId && !in_array($selectedVatId, $vatIds, true)) {
+    $vatIds[] = $selectedVatId;
+}
+if ($vatLocked) {
+    $vatIds = $selectedVatId ? [$selectedVatId] : [];
+}
+
+$vatChoices = [];
+$plans = [];
+$pricesIncludeVat = (bool) setting('Utilizza prezzi di vendita comprensivi di IVA');
+foreach ($vatIds as $vatId) {
+    $vat = Aliquota::find($vatId);
+    if (!$vat) {
+        continue;
+    }
+
+    $title = trim((string) $vat->getTranslation('title'));
+    $rate = (float) $vat->percentuale;
+    $rateText = rtrim(rtrim(number_format($rate, 3, ',', '.'), '0'), ',').'%';
+    $vatChoices[$vatId] = [
+        'id' => $vatId,
+        'text' => $title === '' ? $rateText : (str_contains($title, '%') ? $title : $title.' ('.$rateText.')'),
+    ];
+
+    foreach (['down', 'nearest', 'up'] as $mode) {
+        try {
+            $plan = DocumentRounding::solve($context, $rate, $pricesIncludeVat, $mode);
+            $plans[$vatId][$mode] = [
+                'input' => number_format((float) $plan['input'], DocumentRounding::INPUT_DECIMALS, '.', ''),
+                'target' => (float) $plan['target'],
+                'difference' => (float) $plan['difference'],
+                'adjustment' => (float) $plan['adjustment'],
+                'requires_adjustment' => (bool) $plan['requires_adjustment'],
+            ];
+        } catch (Throwable) {
+            $plans[$vatId][$mode] = null;
+        }
+    }
+}
+
+if (!$vatChoices) {
+    $blockedReasons[] = 'missing_vat';
+}
+if (count($vatChoices) === 1 && !$selectedVatId) {
+    $selectedVatId = (int) array_key_first($vatChoices);
+}
+
+$reasonLabels = [
+    'sectioned_quote' => tr('Il preventivo contiene sezioni: il totale generale non viene arrotondato per non alterare il subtotale dell’ultima sezione.'),
+    'credit_note' => tr('Le note di credito non sono supportate.'),
+    'electronic_invoice_locked' => tr('Lo stato della fattura elettronica non consente modifiche.'),
+    'percentage_collection_fee' => tr('Sono presenti spese d’incasso percentuali.'),
+    'automatic_stamp_duty' => tr('È attivo il bollo automatico.'),
+    'final_discount' => tr('È presente uno sconto finale sul documento.'),
+    'withholdings_or_social_security' => tr('Sono presenti ritenute o cassa previdenziale.'),
+    'duplicate_rounding' => tr('Sono presenti più righe di arrotondamento: rimuovere i duplicati prima di procedere.'),
+    'missing_account' => tr('Imposta il conto predefinito delle fatture di vendita.'),
+    'missing_vat' => tr('Nessuna aliquota IVA disponibile.'),
+];
+
+$format = static function (float $value, int $decimals): string {
+    return Translator::numberToLocale(abs($value) < (0.5 / (10 ** $decimals)) ? 0 : $value, $decimals).' '.currency();
+};
+
+$initial = $selectedVatId ? ($plans[$selectedVatId][$defaultMode] ?? null) : null;
+$currentText = $format((float) $context['source_total'], 3);
+$targetText = $initial ? $format((float) $initial['target'], 2) : '—';
+$differenceText = $initial ? $format((float) $initial['difference'], 3) : '—';
+$canApply = empty($blockedReasons) && $initial && $initial['requires_adjustment'];
+$action = base_path_osm().'/editor.php?id_module='.$id_module.'&id_record='.$id_record;
+
+if ($blockedReasons) {
+    echo '<div class="alert alert-warning"><i class="fa fa-exclamation-triangle"></i><ul class="mb-0">';
+    foreach (array_unique($blockedReasons) as $reason) {
+        echo '<li>'.($reasonLabels[$reason] ?? tr('Documento non arrotondabile.')).'</li>';
+    }
+    echo '</ul></div>';
+}
+
+echo '<form action="'.$action.'" method="post" id="document-rounding-form">
+<input type="hidden" name="backto" value="record-edit">
+<input type="hidden" name="op" value="manage_sconto">
+<input type="hidden" name="idriga" value="'.($existing ? (int) $existing->id : '').'">
+<input type="hidden" name="dir" value="'.htmlspecialchars($dir, ENT_QUOTES, 'UTF-8').'">
+<input type="hidden" name="descrizione" value="'.DocumentRounding::DESCRIPTION.'">
+<input type="hidden" name="note" value="">
+<input type="hidden" name="sconto_unitario" data-role="rounding-input" value="'.($initial['input'] ?? '').'">';
+
+if ($isInvoice) {
+    echo '<input type="hidden" name="id_conto" value="'.(int) $accountId.'">
+<input type="hidden" name="calcolo_ritenuta_acconto" value="">
+<input type="hidden" name="id_ritenuta_acconto" value="">
+<input type="hidden" name="ritenuta_contributi" value="0">
+<input type="hidden" name="id_rivalsa_inps" value="">';
+}
+
+$fixedVat = count($vatChoices) === 1 || $vatLocked;
+if ($fixedVat && $selectedVatId) {
+    echo '<input type="hidden" name="id_iva" data-role="fixed-vat" value="'.$selectedVatId.'">';
+}
+
+echo '<div class="card card-outline card-primary mb-3"><div class="card-body"><div class="row align-items-end">
+<div class="col-md-8"><label>'.tr('Modalità').'</label><div class="btn-group btn-group-toggle d-flex" data-toggle="buttons">';
+foreach (['down' => ['fa-arrow-down', tr('Euro inferiore')], 'nearest' => ['fa-bullseye', tr('Euro più vicino')], 'up' => ['fa-arrow-up', tr('Euro superiore')]] as $mode => $data) {
+    $active = $defaultMode === $mode ? 'btn-primary active' : 'btn-default';
+    echo '<label class="btn '.$active.' flex-fill" data-role="mode-button"><input type="radio" name="rounding_mode" value="'.$mode.'" '.($defaultMode === $mode ? 'checked' : '').'> <i class="fa '.$data[0].'"></i> '.$data[1].'</label>';
+}
+echo '</div></div><div class="col-md-4"><label>'.tr('IVA').'</label>';
+
+if ($fixedVat) {
+    echo '<input type="text" class="form-control" readonly value="'.htmlspecialchars((string) ($vatChoices[$selectedVatId]['text'] ?? ''), ENT_QUOTES, 'UTF-8').'">';
+} else {
+    echo '{[ "type": "select", "name": "id_iva", "id": "rounding-vat", "values": '.json_encode(array_values($vatChoices), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES).', "value": "'.($selectedVatId ?: '').'", "required": 1 ]}';
+}
+
+echo '</div></div></div></div>
+<div class="card card-outline card-secondary mb-3"><div class="card-body p-0"><div class="row no-gutters">
+<div class="col-md-4 p-3 border-right"><div class="text-muted small">'.tr('Totale attuale').'</div><div class="h4 mb-0">'.$currentText.'</div></div>
+<div class="col-md-4 p-3 border-right bg-light"><div class="text-muted small">'.tr('Totale arrotondato').'</div><div class="h4 mb-0 text-primary font-weight-bold" data-role="target">'.$targetText.'</div></div>
+<div class="col-md-4 p-3"><div class="text-muted small">'.tr('Rettifica').'</div><div class="h4 mb-0" data-role="difference">'.$differenceText.'</div></div>
+</div></div></div>
+<div class="row"><div class="col-sm-6">';
+if ($existing) {
+    echo '<button type="button" class="btn btn-danger" id="remove-rounding"><i class="fa fa-trash"></i> '.tr('Rimuovi').'</button>';
+}
+echo '</div><div class="col-sm-6 text-right"><button type="button" class="btn btn-default" data-dismiss="modal">'.tr('Annulla').'</button> <button type="button" class="btn btn-success" id="apply-rounding" '.($canApply ? '' : 'disabled').'><i class="fa fa-check"></i> '.tr('Applica').'</button></div></div>
+</form>';
+
+if ($existing) {
+    echo '<form action="'.$action.'" method="post" id="remove-rounding-form" class="d-none"><input type="hidden" name="backto" value="record-edit"><input type="hidden" name="op" value="delete_riga"><input type="hidden" name="righe[]" value="'.(int) $existing->id.'"></form>';
+}
+
+$plansJson = json_encode($plans, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRESERVE_ZERO_FRACTION);
+$symbol = json_encode((string) currency(), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+$staticCanApply = empty($blockedReasons) ? 'true' : 'false';
+$fixedVatJs = $fixedVat ? 'true' : 'false';
+
+echo '<script>
+(function(){
+const plans='.$plansJson.', symbol='.$symbol.', staticCanApply='.$staticCanApply.', fixedVat='.$fixedVatJs.';
+const form=$("#document-rounding-form"), apply=$("#apply-rounding"), vat=$("#rounding-vat");
+function vatId(){return String(fixedVat ? form.find("[data-role=fixed-vat]").val() : (vat.val()||""));}
+function mode(){return form.find("input[name=rounding_mode]:checked").val()||"nearest";}
+function fmt(value,decimals){let n=Number(value); if(Math.abs(n)<0.5/Math.pow(10,decimals))n=0; return n.toLocaleString(undefined,{minimumFractionDigits:decimals,maximumFractionDigits:decimals})+" "+symbol;}
+function refresh(){form.find("[data-role=mode-button]").removeClass("btn-primary").addClass("btn-default"); form.find("input[name=rounding_mode]:checked").closest("[data-role=mode-button]").removeClass("btn-default").addClass("btn-primary"); const p=plans[vatId()]?plans[vatId()][mode()]:null; if(!p){form.find("[data-role=target],[data-role=difference]").text("—"); apply.prop("disabled",true); return;} form.find("[data-role=target]").text(fmt(p.target,2)); form.find("[data-role=difference]").text(fmt(p.difference,3)); form.find("[data-role=rounding-input]").val(p.input); apply.prop("disabled",!staticCanApply||!p.requires_adjustment);}
+form.on("change","input[name=rounding_mode]",refresh); vat.on("change",refresh);
+apply.on("click",function(){refresh(); if($(this).prop("disabled"))return; salvaForm("#document-rounding-form",{id_module:"'.$id_module.'",id_record:"'.$id_record.'"}).then(function(){form.closest("div[id^=bs-popup]").modal("hide"); if(typeof caricaRighe==="function")caricaRighe(null);});});
+$("#remove-rounding").on("click",function(){salvaForm("#remove-rounding-form",{id_module:"'.$id_module.'",id_record:"'.$id_record.'"}).then(function(){form.closest("div[id^=bs-popup]").modal("hide"); if(typeof caricaRighe==="function")caricaRighe(null);});});
+refresh();
+})();
+</script>';

--- a/modules/contratti/buttons.php
+++ b/modules/contratti/buttons.php
@@ -20,6 +20,8 @@
 
 include_once __DIR__.'/../../core.php';
 
+use Common\DocumentRounding;
+
 if (!$is_anagrafica_deleted) {
     $is_fatturabile = $record['is_fatturabile'];
     $stati_fatturabili = $dbo->fetchOne('SELECT GROUP_CONCAT(`title` SEPARATOR ", ") AS stati_abilitati FROM `co_stati_contratti` LEFT JOIN `co_stati_contratti_lang` ON (`co_stati_contratti`.`id` = `co_stati_contratti_lang`.`id_record` AND `co_stati_contratti_lang`.`id_lang` = '.prepare(Models\Locale::getDefault()->id).') WHERE `is_fatturabile` = 1')['stati_abilitati'];
@@ -46,6 +48,13 @@ if (!$is_anagrafica_deleted) {
             <i class="fa fa-refresh"></i> '.tr('Rinnova').'
         </button>
     </div>';
+}
+
+if (DocumentRounding::defaultMode() !== null && empty($record['is_bloccato'])) {
+    echo '
+<button type="button" class="btn btn-default" data-widget="modal" data-title="'.tr('Arrotonda totale').'" data-href="'.base_path_osm().'/include/document-rounding.php?id_module='.$id_module.'&id_record='.$id_record.'">
+    <i class="fa fa-calculator"></i> '.tr('Arrotonda').'
+</button>';
 }
 
 // Duplica contratto

--- a/modules/fatture/buttons.php
+++ b/modules/fatture/buttons.php
@@ -19,6 +19,7 @@
  */
 
 include_once __DIR__.'/../../core.php';
+use Common\DocumentRounding;
 use Models\Module;
 
 // Pulsante "Attributi avanzati" per fatture di vendita e di acquisto
@@ -132,7 +133,6 @@ if (!empty($record['is_fiscale'])) {
                 <i class="fa fa-euro"></i> '.tr('Registra contabile').'
             </a>';
 
-    // Riapri documento - sempre visibile ma disabilitato se non utilizzabile
     echo '
             <a class="btn dropdown-item '.($record['stato'] == 'Pagato' ? 'ask tip' : 'disabled').'" '.($record['stato'] == 'Pagato' ? 'data-msg="'.tr('Se riapri questo documento verrà azzerato lo scadenzario e la relativa prima nota. Continuare?').'" data-button="'.tr('Procedi').'" data-method="post" data-op="reopen" data-backto="record-edit" data-title="'.tr('Riaprire il documento?').'" title="'.tr("Riporta il documento nello stato di 'Emessa' e ne elimina i movimenti contabili").'"' : '').'>
                 <i class="fa fa-folder-open"></i> '.tr('Riapri documento').'...
@@ -141,6 +141,13 @@ if (!empty($record['is_fiscale'])) {
     echo '
         </ul>
     </div>';
+}
+
+if ($module->name === 'Fatture di vendita' && $record['stato'] === 'Bozza' && empty($record['is_reversed']) && DocumentRounding::defaultMode() !== null) {
+    echo '
+<button type="button" class="btn btn-default" data-widget="modal" data-title="'.tr('Arrotonda totale').'" data-href="'.base_path_osm().'/include/document-rounding.php?id_module='.$id_module.'&id_record='.$id_record.'">
+    <i class="fa fa-calculator"></i> '.tr('Arrotonda').'
+</button>';
 }
 
 // Duplica fattura

--- a/modules/preventivi/buttons.php
+++ b/modules/preventivi/buttons.php
@@ -20,6 +20,7 @@
 
 include_once __DIR__.'/../../core.php';
 
+use Common\DocumentRounding;
 use Modules\Interventi\Intervento;
 use Modules\Preventivi\Stato;
 
@@ -86,6 +87,13 @@ if (!$is_anagrafica_deleted) {
             </a>
         </div>
     </div>';
+}
+
+if (DocumentRounding::defaultMode() !== null && empty($record['is_bloccato'])) {
+    echo '
+<button type="button" class="btn btn-default" data-widget="modal" data-title="'.tr('Arrotonda totale').'" data-href="'.base_path_osm().'/include/document-rounding.php?id_module='.$id_module.'&id_record='.$id_record.'">
+    <i class="fa fa-calculator"></i> '.tr('Arrotonda').'
+</button>';
 }
 
 // Duplica preventivo

--- a/src/Common/DocumentRounding.php
+++ b/src/Common/DocumentRounding.php
@@ -172,9 +172,6 @@ class DocumentRounding
         if (abs((float) ($invoice->pagamento?->importo_percentuale_incasso ?? 0)) > 0.0000001) {
             $reasons[] = 'percentage_collection_fee';
         }
-        if (!empty($invoice->addebita_bollo) && !isset($invoice->bollo)) {
-            $reasons[] = 'automatic_stamp_duty';
-        }
         if (abs((float) ($invoice->sconto_finale ?? 0)) > 0.0000001 || abs((float) ($invoice->sconto_finale_percentuale ?? 0)) > 0.0000001) {
             $reasons[] = 'final_discount';
         }
@@ -186,6 +183,46 @@ class DocumentRounding
         }
 
         return array_values(array_unique($reasons));
+    }
+
+    public static function stampDutyTransition($invoice, int $vatId, array $plan): bool
+    {
+        if (empty($invoice->addebita_bollo) || isset($invoice->bollo)) {
+            return false;
+        }
+
+        $stampNatureCodes = ['N2.1', 'N2.2', 'N3.5', 'N3.6', 'N4'];
+        $stampTaxable = 0.0;
+        $context = self::context($invoice);
+        $existing = $context['existing'];
+
+        foreach ($invoice->getRighe() as $row) {
+            if ($existing && get_class($row) === get_class($existing) && (int) $row->id === (int) $existing->id) {
+                continue;
+            }
+            $nature = (string) ($row->aliquota->codice_natura_fe ?? '');
+            if (in_array($nature, $stampNatureCodes, true)) {
+                $stampTaxable += (float) ($row->subtotale ?? 0);
+            }
+        }
+
+        $stampAmount = abs((float) setting('Importo marca da bollo'));
+        $threshold = abs((float) setting("Soglia minima per l'applicazione della marca da bollo"));
+        $currentStamp = $stampAmount > 0 && abs($stampTaxable) > $threshold;
+
+        $vat = \Modules\Iva\Aliquota::find($vatId);
+        if (!$vat) {
+            return false;
+        }
+        $nature = (string) ($vat->codice_natura_fe ?? '');
+        if (in_array($nature, $stampNatureCodes, true)) {
+            $effects = self::storedEffects((float) $plan['input'], (float) $vat->percentuale, (bool) setting('Utilizza prezzi di vendita comprensivi di IVA'));
+            $stampTaxable -= (float) $effects['net'];
+        }
+
+        $afterStamp = $stampAmount > 0 && abs($stampTaxable) > $threshold;
+
+        return $currentStamp !== $afterStamp;
     }
 
     public static function hasSections($document): bool

--- a/src/Common/DocumentRounding.php
+++ b/src/Common/DocumentRounding.php
@@ -1,0 +1,236 @@
+<?php
+
+namespace Common;
+
+use InvalidArgumentException;
+use RuntimeException;
+use Throwable;
+
+class DocumentRounding
+{
+    public const SETTING = 'Modalità predefinita arrotondamento documenti di vendita';
+    public const DESCRIPTION = 'Arrotondamento';
+    public const INPUT_DECIMALS = 6;
+    public const DISPLAY_DECIMALS = 3;
+
+    public static function defaultMode(): ?string
+    {
+        return match ((string) setting(self::SETTING)) {
+            'Disabilitato' => null,
+            'Euro inferiore' => 'down',
+            'Euro superiore' => 'up',
+            'Euro più vicino' => 'nearest',
+            default => null,
+        };
+    }
+
+    public static function target(float $total, string $mode): float
+    {
+        if (!is_finite($total) || $total < 0) {
+            throw new InvalidArgumentException('Totale non valido.');
+        }
+
+        $mills = (int) round($total * 1000, 0, PHP_ROUND_HALF_UP);
+        $euros = intdiv($mills, 1000);
+        $remainder = $mills % 1000;
+
+        $targetMills = match ($mode) {
+            'down' => $euros * 1000,
+            'up' => ($remainder === 0 ? $euros : $euros + 1) * 1000,
+            'nearest' => ($remainder < 500 ? $euros : $euros + 1) * 1000,
+            default => throw new InvalidArgumentException('Modalità non valida.'),
+        };
+
+        return $targetMills / 1000;
+    }
+
+    public static function context($document, ?int $fallbackVatId = null): array
+    {
+        $managed = [];
+        $needsRevalidation = false;
+
+        foreach ($document->sconti()->get() as $discount) {
+            $isManaged = self::isManaged($discount);
+            $isImported = !empty($discount->original_type);
+
+            if (!$isManaged && $isImported && method_exists($discount, 'getOriginalComponent')) {
+                try {
+                    $original = $discount->getOriginalComponent();
+                    $isManaged = $original && self::isManaged($original);
+                } catch (Throwable) {
+                    $isManaged = false;
+                }
+            }
+
+            if ($isManaged) {
+                $managed[] = $discount;
+                $needsRevalidation = $needsRevalidation || $isImported;
+            }
+        }
+
+        $existing = count($managed) === 1 ? $managed[0] : null;
+        $vatIds = [];
+        $rawTaxable = 0.0;
+        $rawVat = 0.0;
+        $rawSocial = 0.0;
+
+        foreach ($document->getRighe() as $row) {
+            if ($existing && get_class($row) === get_class($existing) && (int) $row->id === (int) $existing->id) {
+                continue;
+            }
+            if (method_exists($row, 'isDescrizione') && $row->isDescrizione()) {
+                continue;
+            }
+
+            $rawTaxable += (float) ($row->totale_imponibile ?? 0);
+            $rawVat += (float) ($row->iva ?? 0) + (float) ($row->iva_rivalsa_inps ?? 0);
+            $rawSocial += (float) ($row->rivalsa_inps ?? 0);
+
+            $idVat = (int) ($row->id_iva ?? 0);
+            if ($idVat > 0) {
+                $vatIds[$idVat] = $idVat;
+            }
+        }
+
+        $vatIds = array_values($vatIds);
+        $sourceTotal = round($rawTaxable + $rawVat + $rawSocial, self::DISPLAY_DECIMALS, PHP_ROUND_HALF_UP);
+        $baseTotal = self::accountingTotal($rawTaxable, $rawVat, $rawSocial);
+
+        if (count($vatIds) > 1) {
+            $existingVat = $existing ? (int) $existing->id_iva : 0;
+            $defaultVat = $existing && !$needsRevalidation && in_array($existingVat, $vatIds, true) ? $existingVat : null;
+        } elseif (count($vatIds) === 1) {
+            $defaultVat = (int) $vatIds[0];
+        } else {
+            $defaultVat = $existing && !$needsRevalidation ? (int) $existing->id_iva : $fallbackVatId;
+        }
+
+        if (!$vatIds && $defaultVat) {
+            $vatIds[] = (int) $defaultVat;
+        }
+
+        return [
+            'existing' => $existing,
+            'duplicate_count' => count($managed),
+            'source_total' => $sourceTotal,
+            'base_total' => $baseTotal,
+            'raw_taxable' => $rawTaxable,
+            'raw_vat' => $rawVat,
+            'raw_social_security' => $rawSocial,
+            'vat_ids' => $vatIds,
+            'default_vat_id' => $defaultVat,
+        ];
+    }
+
+    public static function solve(array $context, float $vatPercent, bool $pricesIncludeVat, string $mode): array
+    {
+        $source = (float) $context['source_total'];
+        $target = self::target($source, $mode);
+        $difference = round($target - $source, self::DISPLAY_DECIMALS, PHP_ROUND_HALF_UP);
+        $base = (float) $context['base_total'];
+
+        if (abs($difference) < 0.0005 && abs($base - $target) < 0.0000001) {
+            return ['target' => $target, 'difference' => 0.0, 'input' => 0.0, 'adjustment' => 0.0, 'requires_adjustment' => false];
+        }
+
+        $startMicros = (int) round(-($target - $source) * 1000000, 0, PHP_ROUND_HALF_UP);
+        for ($offset = 0; $offset <= 20000; ++$offset) {
+            $candidates = $offset === 0 ? [$startMicros] : [$startMicros + $offset, $startMicros - $offset];
+            foreach ($candidates as $candidateMicros) {
+                $effects = self::storedEffects($candidateMicros / 1000000, $vatPercent, $pricesIncludeVat);
+                $predicted = self::accountingTotal(
+                    (float) $context['raw_taxable'] - $effects['net'],
+                    (float) $context['raw_vat'] - $effects['vat'],
+                    (float) $context['raw_social_security']
+                );
+
+                if (abs($predicted - $target) < 0.0000001) {
+                    $adjustment = round(-$effects['gross'], self::INPUT_DECIMALS, PHP_ROUND_HALF_UP);
+                    return [
+                        'target' => $target,
+                        'difference' => $difference,
+                        'input' => $effects['input'],
+                        'adjustment' => $adjustment,
+                        'requires_adjustment' => abs($adjustment) >= 0.0000005,
+                    ];
+                }
+            }
+        }
+
+        throw new RuntimeException('Impossibile determinare una rettifica coerente.');
+    }
+
+    public static function invoiceGuard($invoice): array
+    {
+        $reasons = [];
+        if (!empty($invoice->tipo?->reversed)) {
+            $reasons[] = 'credit_note';
+        }
+        if (in_array((string) ($invoice->codice_stato_fe ?? ''), ['WAIT', 'RC', 'MC', 'QUEUE', 'DT', 'EC01', 'NE'], true)) {
+            $reasons[] = 'electronic_invoice_locked';
+        }
+        if (abs((float) ($invoice->pagamento?->importo_percentuale_incasso ?? 0)) > 0.0000001) {
+            $reasons[] = 'percentage_collection_fee';
+        }
+        if (!empty($invoice->addebita_bollo) && !isset($invoice->bollo)) {
+            $reasons[] = 'automatic_stamp_duty';
+        }
+        if (abs((float) ($invoice->sconto_finale ?? 0)) > 0.0000001 || abs((float) ($invoice->sconto_finale_percentuale ?? 0)) > 0.0000001) {
+            $reasons[] = 'final_discount';
+        }
+        if (abs((float) ($invoice->rivalsa_inps ?? 0)) > 0.0000001
+            || abs((float) ($invoice->ritenuta_acconto ?? 0)) > 0.0000001
+            || abs((float) ($invoice->totale_ritenuta_contributi ?? 0)) > 0.0000001
+            || !empty($invoice->id_ritenuta_contributi)) {
+            $reasons[] = 'withholdings_or_social_security';
+        }
+
+        return array_values(array_unique($reasons));
+    }
+
+    public static function hasSections($document): bool
+    {
+        foreach ($document->getRighe() as $row) {
+            if (method_exists($row, 'isDescrizione') && $row->isDescrizione() && !empty($row->is_titolo)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static function isManaged($discount): bool
+    {
+        $description = str_replace(["\r\n", "\r"], "\n", trim((string) ($discount->descrizione ?? '')));
+        $position = stripos($description, "\nRif.");
+        if ($position !== false) {
+            $description = substr($description, 0, $position);
+        }
+        return strcasecmp(trim($description), self::DESCRIPTION) === 0;
+    }
+
+    private static function accountingTotal(float $taxable, float $vat, float $social = 0.0): float
+    {
+        return round($taxable, 2) + round($vat, 2) + round($social, 2);
+    }
+
+    private static function storedEffects(float $grossDiscount, float $vatPercent, bool $pricesIncludeVat): array
+    {
+        $factor = 1 + $vatPercent / 100;
+        if ($factor <= 0) {
+            throw new InvalidArgumentException('Aliquota IVA non valida.');
+        }
+
+        if ($pricesIncludeVat) {
+            $input = round($grossDiscount, self::INPUT_DECIMALS, PHP_ROUND_HALF_UP);
+            $vatRaw = $input * ($vatPercent / 100) / $factor;
+            $vat = round($vatRaw, self::INPUT_DECIMALS, PHP_ROUND_HALF_UP);
+            $net = round($input - $vatRaw, self::INPUT_DECIMALS, PHP_ROUND_HALF_UP);
+        } else {
+            $input = round($grossDiscount / $factor, self::INPUT_DECIMALS, PHP_ROUND_HALF_UP);
+            $net = $input;
+            $vat = round($input * $vatPercent / 100, self::INPUT_DECIMALS, PHP_ROUND_HALF_UP);
+        }
+
+        return ['input' => $input, 'net' => $net, 'vat' => $vat, 'gross' => round($net + $vat, self::INPUT_DECIMALS, PHP_ROUND_HALF_UP)];
+    }
+}

--- a/tests/Common/DocumentRoundingTest.php
+++ b/tests/Common/DocumentRoundingTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Common;
+
+use Common\DocumentRounding;
+use PHPUnit\Framework\TestCase;
+
+class DocumentRoundingTest extends TestCase
+{
+    /** @dataProvider roundingProvider */
+    public function testTarget(float $value, string $mode, float $expected): void
+    {
+        $this->assertSame($expected, DocumentRounding::target($value, $mode));
+    }
+
+    public static function roundingProvider(): array
+    {
+        return [
+            'nearest below half' => [100.499, 'nearest', 100.0],
+            'nearest at half' => [100.500, 'nearest', 101.0],
+            'nearest above half' => [100.501, 'nearest', 101.0],
+            'down' => [100.999, 'down', 100.0],
+            'up' => [100.001, 'up', 101.0],
+            'already whole up' => [100.0, 'up', 100.0],
+        ];
+    }
+}

--- a/update/2_11_3.sql
+++ b/update/2_11_3.sql
@@ -1,0 +1,7 @@
+-- Modalità predefinita per il comando di arrotondamento dei documenti di vendita
+INSERT INTO `zz_settings` (`nome`, `valore`, `tipo`, `editable`, `sezione`) VALUES
+('Modalità predefinita arrotondamento documenti di vendita', 'Euro più vicino', 'list[Disabilitato,Euro inferiore,Euro superiore,Euro più vicino]', 1, 'Generali');
+
+INSERT INTO `zz_settings_lang` (`id_lang`, `id_record`, `title`, `help`) VALUES
+(1, (SELECT MAX(`id`) FROM `zz_settings`), 'Arrotondamento documenti di vendita', 'Modalità proposta dal comando Arrotonda. Il calcolo considera i millesimi.'),
+(2, (SELECT MAX(`id`) FROM `zz_settings`), 'Sales document rounding', 'Default mode proposed by the Round command. The calculation considers thousandths.');


### PR DESCRIPTION
## Descrizione

Aggiunge l'arrotondamento del totale dei documenti di vendita tramite una normale riga Sconto/Maggiorazione, mantenendo i calcoli standard di OpenSTAManager.

Disponibile per Preventivi, Contratti e Fatture di vendita in Bozza.

Supporta arrotondamento all'euro inferiore, superiore o più vicino, gestione IVA e aggiornamento/rimozione dell'arrotondamento esistente.

Il bollo automatico non costituisce più un blocco generale; resta da proteggere il solo caso limite di attraversamento della soglia del bollo.

Verificata anche la generazione XML FatturaPA.

Closes #1853