### PR TITLE
API per Tipi di documenti

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -5,6 +5,7 @@ $finder = PhpCsFixer\Finder::create()
     ->exclude('files')
     ->exclude('node_modules')
     ->exclude('vendor')
+    ->exclude('storage')
     ->ignoreDotFiles(true)
     ->ignoreVCS(true)
     ->in(__DIR__);

--- a/composer.json
+++ b/composer.json
@@ -127,6 +127,7 @@
             "Modules\\StatiContratto\\": ["modules/stati_contratto/custom/src/", "modules/stati_contratto/src/"],
             "Modules\\StatiOrdine\\": ["modules/stati_ordine/custom/src/", "modules/stati_ordine/src/"],
             "Modules\\TipiIntervento\\": ["modules/tipi_intervento/custom/src/", "modules/tipi_intervento/src/"],
+            "Modules\\TipiDocumento\\": ["modules/tipi_documento/custom/src/", "modules/tipi_documento/src/"],
             "Modules\\CategorieDocumentali\\": ["modules/categorie_documenti/custom/src/", "modules/categorie_documenti/src/"],
             "Modules\\PianiSconto\\": ["modules/piano_sconto/custom/src/", "modules/piano_sconto/src/"],
             "Modules\\Impianti\\": ["modules/impianti/custom/src/", "modules/impianti/src/"],

--- a/modules/impostazioni/src/API/ImpostazioneResource.php
+++ b/modules/impostazioni/src/API/ImpostazioneResource.php
@@ -29,8 +29,8 @@ use Modules\Impostazioni\API\Models\UpdateImpostazioneResponse;
             controller: ListImpostazioniController::class,
             paginationEnabled: false,
             parameters: [
-                'ricerca' => new QueryParameter(property: 'hydra:freetextQuery', required: false),
-                'sezione' => new QueryParameter(property: 'hydra:freetextQuery', required: false),
+                'ricerca' => new QueryParameter(required: false),
+                'sezione' => new QueryParameter(required: false),
             ]
         ),
         new Get(

--- a/modules/tipi_documento/ajax/select.php
+++ b/modules/tipi_documento/ajax/select.php
@@ -22,16 +22,16 @@ include_once __DIR__.'/../../../core.php';
 
 switch ($resource) {
     case 'tipi_documento':
-        $query = 'SELECT `co_tipi_documento`.`id`, `co_tipi_documento_lang`.`title` AS descrizione FROM `co_tipi_documento` |where| ORDER BY `title` ASC';
+        $query = 'SELECT `co_tipi_documento`.`id`, `co_tipi_documento_lang`.`title` AS descrizione FROM `co_tipi_documento` LEFT JOIN `co_tipi_documento_lang` ON (`co_tipi_documento`.`id` = `co_tipi_documento_lang`.`id_record` AND `co_tipi_documento_lang`.`id_lang` = '.prepare(Locale::getDefault()->id).') |where| ORDER BY `title` ASC';
 
         $where[] = '`co_tipi_documento`.`enabled` = 1';
-        $where[] = '`dir`='.prepare($superselect['dir']);
+        $where[] = '`co_tipi_documento`.`dir`='.prepare($superselect['dir']);
 
         foreach ($elements as $element) {
-            $filter[] = '`id`='.prepare($element);
+            $filter[] = '`co_tipi_documento`.`id`='.prepare($element);
         }
         if (!empty($search)) {
-            $search_fields[] = '`title` LIKE '.prepare('%'.$search.'%');
+            $search_fields[] = '`co_tipi_documento_lang`.`title` LIKE '.prepare('%'.$search.'%');
         }
 
         $custom['link'] = 'module:Tipi documento';

--- a/modules/tipi_documento/src/API/Controllers/CreateTipiDocumentoController.php
+++ b/modules/tipi_documento/src/API/Controllers/CreateTipiDocumentoController.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Modules\TipiDocumento\API\Controllers;
+
+use API\Controllers\BaseController;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Models\Locale;
+use Modules\Fatture\Tipo;
+use Modules\TipiDocumento\API\Controllers\Models\CreateTipiDocumentoRequest;
+use Modules\TipiDocumento\API\Controllers\Models\CreateTipiDocumentoResponse;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+
+final class CreateTipiDocumentoController extends BaseController
+{
+    public function __invoke(Request $request): JsonResponse
+    {
+        $data = $this->init($request, CreateTipiDocumentoRequest::class);
+
+        $tipo_new = Tipo::where('name', $data->name)->where('dir', '=', $data->dir)->where('codice_tipo_documento_fe', '=', $data->codice_tipo_documento_fe)->first();
+
+        if (!empty($tipo_new)) {
+            throw new ConflictHttpException(tr('Questa combinazione di nome, codice e direzione è già stata utilizzata per un altro tipo di documento.'));
+        }
+
+        $tipo = Tipo::build($data->dir, $data->codice_tipo_documento_fe);
+        if (Locale::getDefault()->id == Locale::getPredefined()->id) {
+            $tipo->name = $data->name;
+        }
+        $id_record = database()->lastInsertedID();
+        $tipo->save();
+
+        $response = new CreateTipiDocumentoResponse();
+        $response->id = $id_record;
+        $response->text = $data->name;
+
+        return new JsonResponse($response);
+    }
+
+    protected function hasAccess($request): bool
+    {
+        return $this->hasModuleWriteAccess('Tipi documento');
+    }
+}

--- a/modules/tipi_documento/src/API/Controllers/DeleteTipiDocumentoController.php
+++ b/modules/tipi_documento/src/API/Controllers/DeleteTipiDocumentoController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Modules\TipiDocumento\API\Controllers;
+
+use API\Controllers\BaseController;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Modules\Fatture\Tipo;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+final class DeleteTipiDocumentoController extends BaseController
+{
+    public function __invoke(Request $request): JsonResponse
+    {
+        $this->init($request);
+        $id_record = $request->route('id');
+
+        $tipo = Tipo::find($id_record);
+        if (!$tipo) {
+            throw new NotFoundHttpException();
+        }
+
+        $documenti = $dbo->fetchNum('SELECT `id` FROM `co_documenti` WHERE `id_tipo_documento` ='.prepare($id_record));
+
+        if (empty($documenti)) {
+            Tipo::destroy($id_record);
+        } else {
+            $tipo->deleted_at = date();
+            $tipo->predefined = 0;
+            $tipo->enabled = 0;
+            $tipo->save();
+        }
+
+        return new JsonResponse();
+    }
+
+    protected function hasAccess($request): bool
+    {
+        return $this->hasModuleReadAccess('Tipi documento');
+    }
+}

--- a/modules/tipi_documento/src/API/Controllers/GetTipiDocumentoController.php
+++ b/modules/tipi_documento/src/API/Controllers/GetTipiDocumentoController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Modules\TipiDocumento\API\Controllers;
+
+use API\Controllers\BaseController;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Modules\Fatture\Tipo;
+use Modules\TipiDocumento\API\TipiDocumentoResource;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+final class GetTipiDocumentoController extends BaseController
+{
+    public function __invoke(Request $request): JsonResponse
+    {
+        $this->init($request);
+
+        $id_record = $request->route('id');
+
+        $tipo = Tipo::find($id_record);
+        if (empty($tipo)) {
+            throw new NotFoundHttpException();
+        }
+        $response = TipiDocumentoResource::fromModel($tipo);
+
+        return new JsonResponse($response);
+    }
+
+    protected function hasAccess($request): bool
+    {
+        return $this->hasModuleReadAccess('Tipi documento');
+    }
+}

--- a/modules/tipi_documento/src/API/Controllers/Models/CreateTipiDocumentoRequest.php
+++ b/modules/tipi_documento/src/API/Controllers/Models/CreateTipiDocumentoRequest.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Modules\TipiDocumento\API\Controllers\Models;
+
+class CreateTipiDocumentoRequest
+{
+    public string $name;
+    public string $dir;
+    public string $codice_tipo_documento_fe;
+}

--- a/modules/tipi_documento/src/API/Controllers/Models/CreateTipiDocumentoResponse.php
+++ b/modules/tipi_documento/src/API/Controllers/Models/CreateTipiDocumentoResponse.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Modules\TipiDocumento\API\Controllers\Models;
+
+class CreateTipiDocumentoResponse
+{
+    public string $id;
+    public string $text;
+}

--- a/modules/tipi_documento/src/API/Controllers/Models/SelectOptionsTipiDocumentoRequest.php
+++ b/modules/tipi_documento/src/API/Controllers/Models/SelectOptionsTipiDocumentoRequest.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Modules\TipiDocumento\API\Controllers\Models;
+
+use DTO\SelectOptionsRequest;
+
+final class SelectOptionsTipiDocumentoRequest extends SelectOptionsRequest
+{
+    public string $dir;
+}

--- a/modules/tipi_documento/src/API/Controllers/Models/SelectOptionsTipiDocumentoResponse.php
+++ b/modules/tipi_documento/src/API/Controllers/Models/SelectOptionsTipiDocumentoResponse.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Modules\TipiDocumento\API\Controllers\Models;
+
+use DTO\SelectOptionsRecord;
+use DTO\SelectOptionsResponse;
+
+final class SelectOptionsTipiDocumentoRecord extends SelectOptionsRecord
+{
+    public string $descrizione;
+    public string $title;
+}
+
+final class SelectOptionsTipiDocumentoResponse extends SelectOptionsResponse
+{
+    /**
+     * @var SelectOptionsTipiDocumentoRecord[]
+     */
+    public array $results = [];
+}

--- a/modules/tipi_documento/src/API/Controllers/Models/UpdateTipiDocumentoRequest.php
+++ b/modules/tipi_documento/src/API/Controllers/Models/UpdateTipiDocumentoRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Modules\TipiDocumento\API\Controllers\Models;
+
+use Symfony\Component\Serializer\Attribute\Ignore;
+
+class UpdateTipiDocumentoRequest
+{
+    public string $name;
+    public string $dir;
+    public string $codice_tipo_documento_fe;
+    public ?string $help;
+    public bool $predefined;
+    public bool $enabled;
+    public int $id_segment;
+    private int $id; // Da URL
+
+    #[Ignore]
+    public function getId(): int
+    {
+        return $this->id;
+    }
+}

--- a/modules/tipi_documento/src/API/Controllers/SelectOptionsTipiDocumentoController.php
+++ b/modules/tipi_documento/src/API/Controllers/SelectOptionsTipiDocumentoController.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Modules\TipiDocumento\API\Controllers;
+
+use API\Controllers\BaseController;
+use DTO\SelectOptionsRequest;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Models\Locale;
+use Symfony\Component\HttpKernel\Exception\InvalidMetadataException;
+
+final class SelectOptionsTipiDocumentoRequest extends SelectOptionsRequest
+{
+    public string $dir;
+}
+
+final class SelectOptionsTipiDocumentoController extends BaseController
+{
+    public function __invoke(Request $request): JsonResponse
+    {
+        $body = $this->init($request, SelectOptionsTipiDocumentoRequest::class);
+        $dir = $body->dir;
+
+        if (empty($dir)) {
+            throw new InvalidMetadataException('Missing dir option');
+        }
+
+        $query = 'SELECT `co_tipi_documento`.`id`, `co_tipi_documento_lang`.`title` AS descrizione FROM `co_tipi_documento` LEFT JOIN `co_tipi_documento_lang` ON (`co_tipi_documento`.`id` = `co_tipi_documento_lang`.`id_record` AND `co_tipi_documento_lang`.`id_lang` = '.prepare(Locale::getDefault()->id).') |where| ORDER BY `title` ASC';
+
+        $where = ['`co_tipi_documento`.`enabled` = 1',  '`co_tipi_documento`.`dir`='.prepare($dir)];
+        $filter = [];
+        $search_fields = [];
+        foreach ((array) $body->retrieve_only_for as $element) {
+            $filter[] = '`co_tipi_documento`.`id`='.prepare($element);
+        }
+
+        if (!empty($body->search)) {
+            $search_fields[] = '`co_tipi_documento_lang`.`title` LIKE '.prepare('%'.$body->search.'%');
+        }
+
+        $custom = [
+            'id' => 'id',
+            'text' => 'descrizione',
+        ];
+        $length = 200;
+        $query_results = \AJAX::selectResults($query, $where, $filter, $search_fields, [
+            'offset' => $body->page * $length,
+            'length' => $length,
+        ], $custom);
+
+        $results = $query_results['results'];
+
+        // Applicazione della trasformazione dei link se specificata nelle opzioni
+        $link = 'module:Tipi documento';
+        if (!empty($link) && !empty($results)) {
+            $results = \AJAX::applyLinkTransformation($results, $link);
+        }
+
+        return new JsonResponse([
+            'results' => $results ?: [],
+            'recordsFiltered' => $query_results['recordsFiltered'],
+        ]);
+    }
+
+    protected function hasAccess($request): bool
+    {
+        return $this->hasModuleWriteAccess('Tipi documento');
+    }
+}

--- a/modules/tipi_documento/src/API/Controllers/UpdateTipiDocumentoController.php
+++ b/modules/tipi_documento/src/API/Controllers/UpdateTipiDocumentoController.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Modules\TipiDocumento\API\Controllers;
+
+use API\Controllers\BaseController;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Models\Locale;
+use Modules\Fatture\Tipo;
+use Modules\TipiDocumento\API\Controllers\Models\UpdateTipiDocumentoRequest;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+
+final class UpdateTipiDocumentoController extends BaseController
+{
+    public function __invoke(Request $request): JsonResponse
+    {
+        $data = $this->init($request, UpdateTipiDocumentoRequest::class);
+
+        $tipo_new = Tipo::where('name', $data->name)->where('dir', '=', $data->dir)->where('codice_tipo_documento_fe', '=', $data->codice_tipo_documento_fe)->first();
+
+        if (!empty($tipo_new) && $tipo_new->id != $data->getId()) {
+            throw new ConflictHttpException(tr('Questa combinazione di nome, codice e direzione è già stata utilizzata per un altro tipo di documento.'));
+        }
+        if (!empty($predefined)) {
+            Tipo::where('dir', $data->dir)->update(['predefined' => 0]);
+        }
+
+        $tipo = Tipo::find($data->getId());
+        if (Locale::getDefault()->id == Locale::getPredefined()->id) {
+            $tipo->name = $data->name;
+        }
+        $tipo->dir = $data->dir;
+        $tipo->codice_tipo_documento_fe = $data->codice_tipo_documento_fe;
+        $tipo->help = $data->help;
+        $tipo->predefined = $data->predefined;
+        $tipo->enabled = $data->enabled;
+        $tipo->id_segment = $data->id_segment;
+        $tipo->save();
+
+        $tipo->setTranslation('title', $data->name);
+
+        return new JsonResponse();
+    }
+
+    protected function hasAccess($request): bool
+    {
+        return $this->hasModuleWriteAccess('Tipi documento');
+    }
+}

--- a/modules/tipi_documento/src/API/TipoDocumentiResource.php
+++ b/modules/tipi_documento/src/API/TipoDocumentiResource.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Modules\TipiDocumento\API;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Delete;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\Put;
+use Modules\Fatture\Tipo;
+use Modules\TipiDocumento\API\Controllers\CreateTipiDocumentoController;
+use Modules\TipiDocumento\API\Controllers\DeleteTipiDocumentoController;
+use Modules\TipiDocumento\API\Controllers\GetTipiDocumentoController;
+use Modules\TipiDocumento\API\Controllers\Models\CreateTipiDocumentoRequest;
+use Modules\TipiDocumento\API\Controllers\Models\CreateTipiDocumentoResponse;
+use Modules\TipiDocumento\API\Controllers\Models\UpdateTipiDocumentoRequest;
+use Modules\TipiDocumento\API\Controllers\UpdateTipiDocumentoController;
+
+#[ApiResource(
+    shortName: 'TipiDocumenti',
+    operations: [
+        /*
+        new GetCollection(
+            uriTemplate: '/tipi-documenti',
+            controller: ListTipiDocumentoController::class,
+            paginationEnabled: false,
+        ),
+        */
+        new Get(
+            uriTemplate: '/tipo-documenti/{id}',
+            controller: GetTipiDocumentoController::class,
+        ),
+        new Post(
+            uriTemplate: '/tipo-documenti',
+            controller: CreateTipiDocumentoController::class,
+            input: CreateTipiDocumentoRequest::class,
+            output: CreateTipiDocumentoResponse::class,
+        ),
+        new Put(
+            uriTemplate: '/tipo-documenti/{id}',
+            controller: UpdateTipiDocumentoController::class,
+            input: UpdateTipiDocumentoRequest::class,
+        ),
+        new Delete(
+            uriTemplate: '/tipo-documenti/{id}',
+            controller: DeleteTipiDocumentoController::class,
+        ),
+    ],
+)]
+class TipiDocumentoResource
+{
+    public function __construct(
+        public int $id,
+        public string $name,
+        public bool $reversed,
+        public string $dir,
+        public string $codice_tipo_documento_fe,
+        public ?string $help,
+        public bool $predefined,
+        public bool $enabled,
+        public int $id_segment,
+        public ?string $deleted_at,
+        public ?string $created_at,
+        public ?string $updated_at,
+    ) {
+    }
+
+    public static function fromModel(Tipo $record)
+    {
+        return new self(
+            id: $record->id,
+            name: $record->name,
+            reversed: $record->reversed,
+            dir: $record->dir,
+            codice_tipo_documento_fe: $record->codice_tipo_documento_fe,
+            help: $record->help,
+            predefined: $record->predefined,
+            enabled: $record->enabled,
+            id_segment: $record->id_segment,
+            deleted_at: $record->deleted_at,
+            created_at: $record->created_at,
+            updated_at: $record->updated_at,
+        );
+    }
+}

--- a/modules/tipi_documento/src/API/TipoDocumentiResource.php
+++ b/modules/tipi_documento/src/API/TipoDocumentiResource.php
@@ -5,28 +5,34 @@ namespace Modules\TipiDocumento\API;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Delete;
 use ApiPlatform\Metadata\Get;
-use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Post;
 use ApiPlatform\Metadata\Put;
+use ApiPlatform\Metadata\QueryParameter;
 use Modules\Fatture\Tipo;
 use Modules\TipiDocumento\API\Controllers\CreateTipiDocumentoController;
 use Modules\TipiDocumento\API\Controllers\DeleteTipiDocumentoController;
 use Modules\TipiDocumento\API\Controllers\GetTipiDocumentoController;
 use Modules\TipiDocumento\API\Controllers\Models\CreateTipiDocumentoRequest;
 use Modules\TipiDocumento\API\Controllers\Models\CreateTipiDocumentoResponse;
+use Modules\TipiDocumento\API\Controllers\Models\SelectOptionsTipiDocumentoResponse;
 use Modules\TipiDocumento\API\Controllers\Models\UpdateTipiDocumentoRequest;
+use Modules\TipiDocumento\API\Controllers\SelectOptionsTipiDocumentoController;
 use Modules\TipiDocumento\API\Controllers\UpdateTipiDocumentoController;
 
 #[ApiResource(
     shortName: 'TipiDocumenti',
     operations: [
-        /*
-        new GetCollection(
-            uriTemplate: '/tipi-documenti',
-            controller: ListTipiDocumentoController::class,
-            paginationEnabled: false,
+        new Get(
+            uriTemplate: '/select-options/tipi-documenti',
+            controller: SelectOptionsTipiDocumentoController::class,
+            parameters: [
+                'dir' => new QueryParameter(required: false),
+                'page' => new QueryParameter(required: false),
+                'search' => new QueryParameter(required: false),
+                'retrieve_only_for' => new QueryParameter(required: false, schema: ['type' => 'array']),
+            ],
+            output: SelectOptionsTipiDocumentoResponse::class,
         ),
-        */
         new Get(
             uriTemplate: '/tipo-documenti/{id}',
             controller: GetTipiDocumentoController::class,

--- a/src/AJAX.php
+++ b/src/AJAX.php
@@ -311,7 +311,7 @@ class AJAX
      *
      * @return array
      */
-    protected static function applyLinkTransformation($list, $link)
+    public static function applyLinkTransformation($list, $link)
     {
         foreach ($list as &$element) {
             // Gestione degli elementi con children (optgroup)

--- a/src/API/Controllers/BaseController.php
+++ b/src/API/Controllers/BaseController.php
@@ -2,6 +2,9 @@
 
 namespace API\Controllers;
 
+use CuyZ\Valinor\Mapper\Configurator\ConvertKeysToSnakeCase;
+use CuyZ\Valinor\Mapper\MappingError;
+use CuyZ\Valinor\MapperBuilder;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
@@ -11,7 +14,7 @@ use Models\Plugin;
 
 class InvalidInputException extends \Exception
 {
-    public function __construct(\CuyZ\Valinor\Mapper\MappingError $error)
+    public function __construct(MappingError $error)
     {
         $messages = $error->messages();
 
@@ -86,16 +89,19 @@ abstract class BaseController extends Controller
     protected function _cast(Request $request, string $class_reference): mixed
     {
         try {
-            return (new \CuyZ\Valinor\MapperBuilder())
+            return (new MapperBuilder())
                 ->allowUndefinedValues()
                 ->allowSuperfluousKeys()
                 ->allowScalarValueCasting()
+                ->configureWith(
+                    new ConvertKeysToSnakeCase(),
+                )
                 ->mapper()
                 ->map(
                     $class_reference,
                     [...$request->route()->parameters(), ...$request->all()]
                 );
-        } catch (\CuyZ\Valinor\Mapper\MappingError $error) {
+        } catch (MappingError $error) {
             throw new InvalidInputException($error);
         }
     }

--- a/src/API/Controllers/BaseController.php
+++ b/src/API/Controllers/BaseController.php
@@ -27,6 +27,39 @@ class InvalidInputException extends \Exception
     }
 }
 
+// https://www.php.net/manual/en/function.parse-str.php//76792
+function proper_parse_str($str) {
+  // result array
+  $arr = array();
+
+  // split on outer delimiter
+  $pairs = explode('&', $str);
+
+  // loop through each pair
+  foreach ($pairs as $i) {
+    // split into name and value
+    list($name,$value) = explode('=', $i, 2);
+    
+    // if name already exists
+    if( isset($arr[$name]) ) {
+      // stick multiple values into an array
+      if( is_array($arr[$name]) ) {
+        $arr[$name][] = $value;
+      }
+      else {
+        $arr[$name] = array($arr[$name], $value);
+      }
+    }
+    // otherwise, simply stick it in a scalar
+    else {
+      $arr[$name] = $value;
+    }
+  }
+
+  // return result array
+  return $arr;
+}
+
 abstract class BaseController extends Controller
 {
     abstract protected function hasAccess($request): bool;
@@ -88,6 +121,7 @@ abstract class BaseController extends Controller
      */
     protected function _cast(Request $request, string $class_reference): mixed
     {
+        $query_params = proper_parse_str($_SERVER['QUERY_STRING']);
         try {
             return (new MapperBuilder())
                 ->allowUndefinedValues()
@@ -99,7 +133,7 @@ abstract class BaseController extends Controller
                 ->mapper()
                 ->map(
                     $class_reference,
-                    [...$request->route()->parameters(), ...$request->all()]
+                    [...$request->route()->parameters(), ...$request->all(), ...$query_params]
                 );
         } catch (MappingError $error) {
             throw new InvalidInputException($error);

--- a/src/API/Controllers/SelectOptionsController.php
+++ b/src/API/Controllers/SelectOptionsController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace API\Controllers;
+
+use DTO\SelectOptionsRequest;
+
+abstract class SelectOptionsController extends BaseController
+{
+    public function __invoke(Request $request): JsonResponse
+    {
+        $body = $this->init($request, SelectOptionsRequest::class);
+        
+        $where = [];
+        $filter = [];
+        $search_fields = [];
+
+        $custom = [
+            'id' => 'id',
+            'text' => 'descrizione',
+        ];
+
+        require $file;
+
+        if (!isset($results) && !empty($query)) {
+            $results = \AJAX::selectResults($query, $where, $filter, $search_fields, $limit, $custom);
+        }
+
+        return new JsonResponse($results ?? null);
+    }
+
+
+    protected function hasAccess($request): bool
+    {
+        return true;
+    }
+}

--- a/src/DTO/SelectOptionsRecord.php
+++ b/src/DTO/SelectOptionsRecord.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace DTO;
+
+class SelectOptionsRecord
+{
+    public string $id;
+    public string $text;
+}

--- a/src/DTO/SelectOptionsRequest.php
+++ b/src/DTO/SelectOptionsRequest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace DTO;
+
+class SelectOptionsRequest
+{
+    public ?string $search = null;
+    public ?int $page = 0;
+    /**
+     * @var array<string>|string
+     */
+    public mixed $retrieve_only_for = [];
+}

--- a/src/DTO/SelectOptionsResponse.php
+++ b/src/DTO/SelectOptionsResponse.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace DTO;
+
+class SelectOptionsResponse
+{
+    /**
+     * @var SelectOptionsRecord[]
+     */
+    public array $results = [];
+    public int $recordsFiltered = 0;
+}


### PR DESCRIPTION
## Descrizione

Aggiunta base API per modulo Tipi di documenti, come ulteriore esperimento al riguardo.

Introduce anche una sezione per select-options utilizzabile via select2 ajax loading direttamente.

In quanto questo modulo è molto semplice, si può sperimentare con esso per provare completamente l'utilizzo dell'API Laravel come fonti dati al posto di query interne ai file che gestiscono la grafica del gestionale (TBD).