### PR TITLE
Disabilitare banca

### DIFF
--- a/modules/banche/actions.php
+++ b/modules/banche/actions.php
@@ -63,7 +63,8 @@ switch (filter('op')) {
         $banca->codice_sia = post('codice_sia');
         $banca->commissioni_riba_insolute = post('commissioni_riba_insolute');
 
-        $banca->predefined = post('predefined');
+        $banca->enabled = post('enabled');
+        $banca->predefined = $banca->enabled ? post('predefined') : 0;
 
         $banca->save();
 

--- a/modules/banche/ajax/select.php
+++ b/modules/banche/ajax/select.php
@@ -34,6 +34,7 @@ switch ($resource) {
 
         if (empty($filter)) {
             $where[] = 'deleted_at IS NULL';
+            $where[] = 'enabled = 1';
         }
 
         $where[] = 'id_anagrafica='.prepare($superselect['id_anagrafica']);

--- a/modules/banche/edit.php
+++ b/modules/banche/edit.php
@@ -43,7 +43,11 @@ $endpoint = setting('Endpoint ibanapi.com');
                     {[ "type": "checkbox", "label": "<?php echo tr('Predefinito'); ?>", "name": "predefined", "value": "$predefined$", "disabled": "<?php echo intval($record['predefined']); ?>" ]}
                 </div>
 
-                <div class="col-md-6">
+                <div class="col-md-2">
+                    {[ "type": "checkbox", "label": "<?php echo tr('Attivo'); ?>", "name": "enabled", "value": "$enabled$" ]}
+                </div>
+
+                <div class="col-md-4">
                     {[ "type": "text", "label": "<?php echo tr('Nome'); ?>", "name": "nome", "required": "1", "value": "$nome$" ]}
                 </div>
             </div>

--- a/modules/banche/src/Banca.php
+++ b/modules/banche/src/Banca.php
@@ -51,6 +51,7 @@ class Banca extends Model
         $model->nome = $nome;
         $model->iban = $iban;
         $model->bic = $bic;
+        $model->enabled = 1;
 
         // Salvataggio delle informazioni
         $model->save();
@@ -84,11 +85,20 @@ class Banca extends Model
 
     protected function fixPredefined()
     {
+        $enabled = $this->enabled ?? true;
         $predefined = $this->predefined ?? false;
 
-        // Selezione automatica per primo record
+        // Una banca disabilitata non può essere predefinita.
+        if (empty($enabled)) {
+            $this->attributes['predefined'] = 0;
+
+            return;
+        }
+
+        // Selezione automatica per primo record attivo.
         $count = self::where('id_anagrafica', $this->id_anagrafica)
             ->where('id', '!=', $this->id)
+            ->where('enabled', 1)
             ->count();
         if (empty($predefined) && empty($count)) {
             $predefined = true;

--- a/update/2_12.sql
+++ b/update/2_12.sql
@@ -102,3 +102,6 @@ INSERT INTO `zz_settings` (`nome`, `valore`, `tipo`, `editable`, `sezione`, `ord
 INSERT INTO `zz_settings_lang` (`id_lang`, `id_record`, `title`, `help`) VALUES
 (1, (SELECT `id` FROM `zz_settings` WHERE `nome` = 'Tipologia anagrafica predefinita'), 'Tipologia anagrafica predefinita', 'Tipologia (Azienda, Ente pubblico o Privato) preselezionata automaticamente nella finestra di aggiunta di una nuova anagrafica. Se non impostata, nessuna tipologia viene preselezionata.'),
 (2, (SELECT `id` FROM `zz_settings` WHERE `nome` = 'Tipologia anagrafica predefinita'), 'Default entity classification', 'Classification (Company, Public entity or Private) automatically preselected in the new entity creation window. If not set, no classification is preselected.');
+
+-- Gestione stato attivo delle banche
+ALTER TABLE `co_banche` ADD `enabled` TINYINT(1) NOT NULL DEFAULT 1 AFTER `predefined`;


### PR DESCRIPTION
Aggiunge la possibilità di disabilitare una banca senza eliminarla.

- aggiunto stato Attivo nel modulo Banche
- escluse le banche disabilitate dalle nuove selezioni
- mantenuta la visualizzazione nei documenti già collegati
- una banca disabilitata non può essere predefinita

Closes #1740