### PR TITLE
Tipi scadenze: corregge TypeError sul conteggio

### DIFF
--- a/modules/tipi_scadenze/edit.php
+++ b/modules/tipi_scadenze/edit.php
@@ -58,7 +58,7 @@ if ($tipo->can_delete) {
         echo '
 	<div class="alert alert-danger">
 		'.tr('Ci sono _NUM_ scadenze collegate', [
-            '_NUM_' => count($scadenze),
+            '_NUM_' => $scadenze,
         ]).'.
 	</div>';
     } ?>


### PR DESCRIPTION
Corregge il conteggio delle scadenze collegate nel modulo Tipi scadenze: `fetchNum()` restituisce già un intero, quindi non va passato a `count()`.

Fixes #1893